### PR TITLE
Remove unnecessary tests

### DIFF
--- a/regression-tests/suites/resmoke_psmdb_4.2.txt
+++ b/regression-tests/suites/resmoke_psmdb_4.2.txt
@@ -90,11 +90,11 @@ multi_shard_multi_stmt_txn_jscore_passthrough|inMemory
 multi_stmt_txn_jscore_passthrough_with_migration|inMemory
  multiversion|wiredTiger|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 3.2 3.4 3.6 4.0 4.0.1 4.0.5 4.2.1 4.2.3
  multiversion_auth|wiredTiger|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 3.2 3.4 3.6 4.0 4.0.1 4.0.5 4.2.1 4.2.3
-no_passthrough|inMemory
-no_passthrough_with_mongod|inMemory
+no_passthrough --jobs=1|inMemory
+no_passthrough_with_mongod --storageEngineCacheSizeGB=10 --jobs=1|inMemory
 parallel --jobs=1|inMemory
 parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|inMemory
-percona_no_passthrough_with_mongod|inMemory
+percona_no_passthrough_with_mongod --jobs=1|inMemory
 ratelimit|inMemory
 read_concern_linearizable_passthrough|inMemory
 read_concern_majority_passthrough|inMemory
@@ -160,7 +160,7 @@ backup_tde_cbc|wiredTiger
 backup_tde_gcm|wiredTiger
 benchmarks --jobs=1 --perfReportFile=perf.json|wiredTiger
 benchmarks_sharding --jobs=1 --perfReportFile=perf_sharding.json|wiredTiger
-buildscripts_test|wiredTiger
+ buildscripts_test|wiredTiger
 bulk_gle_passthrough|wiredTiger
 causally_consistent_jscore_passthrough|wiredTiger
 causally_consistent_jscore_passthrough_auth|wiredTiger

--- a/regression-tests/suites/resmoke_psmdb_4.4.txt
+++ b/regression-tests/suites/resmoke_psmdb_4.4.txt
@@ -18,7 +18,7 @@ backup_tde_cbc|wiredTiger
 backup_tde_gcm|wiredTiger
 benchmarks --jobs=1 --perfReportFile=perf.json|wiredTiger
 benchmarks_sharding --jobs=1 --perfReportFile=perf_sharding.json|wiredTiger
-buildscripts_test|wiredTiger
+ buildscripts_test|wiredTiger
 bulk_gle_passthrough|wiredTiger
 causally_consistent_hedged_reads_jscore_passthrough|wiredTiger
 causally_consistent_jscore_passthrough|wiredTiger
@@ -50,7 +50,7 @@ concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger
 concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger
 concurrency_replication_ubsan --jobs=1|wiredTiger
 concurrency_replication_wiredtiger_cursor_sweeps --jobs=1|wiredTiger
-concurrency_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
+ concurrency_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
 concurrency_sharded_causal_consistency --jobs=1|wiredTiger
 concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger
 concurrency_sharded_clusterwide_ops_add_remove_shards --jobs=1|wiredTiger
@@ -70,7 +70,7 @@ concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger
 concurrency_simultaneous --jobs=1|wiredTiger
 concurrency_simultaneous_replication --jobs=1|wiredTiger
 concurrency_simultaneous_replication_wiredtiger_cursor_sweeps --jobs=1|wiredTiger
-concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
+ concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
 core|wiredTiger
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|wiredTiger
 core_auth|wiredTiger
@@ -92,7 +92,7 @@ external_auth_aws|wiredTiger
 failpoints|wiredTiger
 failpoints_auth|wiredTiger
 fle|wiredTiger
-free_monitoring|wiredTiger
+ free_monitoring|wiredTiger
 generational_fuzzer|wiredTiger
 generational_fuzzer_replication|wiredTiger
 gle_auth --shellWriteMode=legacy --shellReadMode=legacy --excludeWithAnyTags=requires_find_command|wiredTiger
@@ -292,7 +292,7 @@ concurrency_replication_multi_stmt_txn --jobs=1|inMemory
 concurrency_replication_multi_stmt_txn_ubsan --jobs=1|inMemory
 concurrency_replication_ubsan --jobs=1|inMemory
 concurrency_replication_wiredtiger_cursor_sweeps --jobs=1|inMemory
-concurrency_replication_wiredtiger_eviction_debug --jobs=1|inMemory
+ concurrency_replication_wiredtiger_eviction_debug --jobs=1|inMemory
 concurrency_sharded_causal_consistency --jobs=1|inMemory
 concurrency_sharded_causal_consistency_and_balancer --jobs=1|inMemory
 concurrency_sharded_clusterwide_ops_add_remove_shards --jobs=1|inMemory
@@ -312,7 +312,7 @@ concurrency_sharded_with_stepdowns_and_balancer --jobs=1|inMemory
 concurrency_simultaneous --jobs=1|inMemory
 concurrency_simultaneous_replication --jobs=1|inMemory
 concurrency_simultaneous_replication_wiredtiger_cursor_sweeps --jobs=1|inMemory
-concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|inMemory
+ concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|inMemory
 core|inMemory
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command|inMemory
 core_auth|inMemory
@@ -334,7 +334,7 @@ external_auth_aws|inMemory
 failpoints|inMemory
 failpoints_auth|inMemory
 fle|inMemory
-free_monitoring|inMemory
+ free_monitoring|inMemory
 generational_fuzzer|inMemory
 generational_fuzzer_replication|inMemory
 gle_auth --shellWriteMode=legacy --shellReadMode=legacy --excludeWithAnyTags=requires_find_command|inMemory
@@ -390,13 +390,13 @@ multi_shard_multi_stmt_txn_stepdown_primary_jscore_passthrough|inMemory
 multi_stmt_txn_jscore_passthrough_with_migration|inMemory
  multiversion|inMemory|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 3.2 3.4 3.6 4.0 4.0.1 4.0.5 4.2 4.2.1 4.4.1
  multiversion_auth|inMemory|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 3.2 3.4 3.6 4.0 4.0.1 4.0.5 4.2 4.2.1 4.4.1
-no_passthrough|inMemory
-no_passthrough_with_mongod|inMemory
+no_passthrough --jobs=1|inMemory
+no_passthrough_with_mongod --storageEngineCacheSizeGB=10 --jobs=1|inMemory
  no_server|inMemory
 ocsp --jobs=1|inMemory
 parallel --jobs=1|inMemory
 parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|inMemory
-percona_no_passthrough_with_mongod|inMemory
+percona_no_passthrough_with_mongod --jobs=1|inMemory
 ratelimit|inMemory
 read_concern_linearizable_passthrough|inMemory
 read_concern_majority_passthrough|inMemory

--- a/regression-tests/suites/resmoke_psmdb_5.0.txt
+++ b/regression-tests/suites/resmoke_psmdb_5.0.txt
@@ -19,7 +19,7 @@ backup_tde_gcm|wiredTiger
 benchmarks --jobs=1 --perfReportFile=perf.json|wiredTiger
 benchmarks_cst --jobs=1|wiredTiger
 benchmarks_sharding --jobs=1 --perfReportFile=perf_sharding.json|wiredTiger
-buildscripts_test|wiredTiger
+ buildscripts_test|wiredTiger
 bulk_gle_passthrough|wiredTiger
 causally_consistent_hedged_reads_jscore_passthrough|wiredTiger
 causally_consistent_jscore_passthrough|wiredTiger
@@ -56,7 +56,7 @@ concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger
 concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger
 concurrency_replication_ubsan --jobs=1|wiredTiger
 concurrency_replication_wiredtiger_cursor_sweeps --jobs=1|wiredTiger
-concurrency_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
+ concurrency_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
 concurrency_sharded_causal_consistency --jobs=1|wiredTiger
 concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger
 concurrency_sharded_clusterwide_ops_add_remove_shards --jobs=1|wiredTiger
@@ -76,7 +76,7 @@ concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger
 concurrency_simultaneous --jobs=1|wiredTiger
 concurrency_simultaneous_replication --jobs=1|wiredTiger
 concurrency_simultaneous_replication_wiredtiger_cursor_sweeps --jobs=1|wiredTiger
-concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
+ concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
 core|wiredTiger
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command,requires_timeseries|wiredTiger
 core_auth|wiredTiger
@@ -86,7 +86,7 @@ core_tde_cbc|wiredTiger
 core_tde_gcm|wiredTiger
 core_txns|wiredTiger
 core_txns_large_txns_format|wiredTiger
-cst_jscore_passthrough|wiredTiger
+ cst_jscore_passthrough|wiredTiger
 cwrwc_passthrough|wiredTiger
 cwrwc_rc_majority_passthrough|wiredTiger
 cwrwc_wc_majority_passthrough|wiredTiger
@@ -98,9 +98,9 @@ external_auth|wiredTiger|/etc/init.d/slapd start && /etc/init.d/saslauthd start
 external_auth_aws|wiredTiger
 failpoints|wiredTiger
 failpoints_auth|wiredTiger
-feature_flag_multiversion|wiredTiger
+ feature_flag_multiversion|wiredTiger
 fle|wiredTiger
-free_monitoring|wiredTiger
+ free_monitoring|wiredTiger
 generational_fuzzer|wiredTiger
 generational_fuzzer_replication|wiredTiger
 gle_auth --shellWriteMode=legacy --shellReadMode=legacy --excludeWithAnyTags=requires_find_command|wiredTiger
@@ -321,7 +321,7 @@ concurrency_replication_multi_stmt_txn --jobs=1|inMemory
 concurrency_replication_multi_stmt_txn_ubsan --jobs=1|inMemory
 concurrency_replication_ubsan --jobs=1|inMemory
 concurrency_replication_wiredtiger_cursor_sweeps --jobs=1|inMemory
-concurrency_replication_wiredtiger_eviction_debug --jobs=1|inMemory
+ concurrency_replication_wiredtiger_eviction_debug --jobs=1|inMemory
 concurrency_sharded_causal_consistency --jobs=1|inMemory
 concurrency_sharded_causal_consistency_and_balancer --jobs=1|inMemory
 concurrency_sharded_clusterwide_ops_add_remove_shards --jobs=1|inMemory
@@ -341,7 +341,7 @@ concurrency_sharded_with_stepdowns_and_balancer --jobs=1|inMemory
 concurrency_simultaneous --jobs=1|inMemory
 concurrency_simultaneous_replication --jobs=1|inMemory
 concurrency_simultaneous_replication_wiredtiger_cursor_sweeps --jobs=1|inMemory
-concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|inMemory
+ concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|inMemory
 core|inMemory
 core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command,requires_timeseries|inMemory
 core_auth|inMemory
@@ -351,7 +351,7 @@ core_op_query|inMemory
  core_tde_gcm|inMemory
 core_txns|inMemory
 core_txns_large_txns_format|inMemory
-cst_jscore_passthrough|inMemory
+ cst_jscore_passthrough|inMemory
 cwrwc_passthrough|inMemory
 cwrwc_rc_majority_passthrough|inMemory
 cwrwc_wc_majority_passthrough|inMemory
@@ -363,9 +363,9 @@ ese|inMemory
 external_auth_aws|inMemory
 failpoints|inMemory
 failpoints_auth|inMemory
-feature_flag_multiversion|inMemory
+ feature_flag_multiversion|inMemory
 fle|inMemory
-free_monitoring|inMemory
+ free_monitoring|inMemory
 generational_fuzzer|inMemory
 generational_fuzzer_replication|inMemory
 gle_auth --shellWriteMode=legacy --shellReadMode=legacy --excludeWithAnyTags=requires_find_command|inMemory
@@ -421,13 +421,13 @@ multi_shard_multi_stmt_txn_stepdown_primary_jscore_passthrough|inMemory
 multi_stmt_txn_jscore_passthrough_with_migration|inMemory
  multiversion|inMemory|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 3.2 3.4 3.6 4.0 4.0.1 4.0.5 4.2 4.2.1 4.4 4.9
  multiversion_auth|inMemory|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 3.2 3.4 3.6 4.0 4.0.1 4.0.5 4.2 4.2.1 4.4 4.9
-no_passthrough|inMemory
-no_passthrough_with_mongod|inMemory
+no_passthrough --jobs=1|inMemory
+no_passthrough_with_mongod --storageEngineCacheSizeGB=10 --jobs=1|inMemory
  no_server|inMemory
 ocsp --jobs=1|inMemory
 parallel --jobs=1|inMemory
 parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|inMemory
-percona_no_passthrough_with_mongod|inMemory
+percona_no_passthrough_with_mongod --jobs=1|inMemory
 ratelimit|inMemory
 read_concern_linearizable_passthrough|inMemory
 read_concern_majority_passthrough|inMemory

--- a/regression-tests/suites/resmoke_psmdb_6.0.txt
+++ b/regression-tests/suites/resmoke_psmdb_6.0.txt
@@ -19,7 +19,7 @@ backup_tde_gcm|wiredTiger
 benchmarks --jobs=1 --perfReportFile=perf.json|wiredTiger
 benchmarks_bsoncolumn --jobs=1|wiredTiger
 benchmarks_sharding --jobs=1 --perfReportFile=perf_sharding.json|wiredTiger
-buildscripts_test|wiredTiger
+ buildscripts_test|wiredTiger
 causally_consistent_hedged_reads_jscore_passthrough|wiredTiger
 causally_consistent_jscore_passthrough|wiredTiger
 causally_consistent_jscore_passthrough_auth|wiredTiger
@@ -62,7 +62,7 @@ concurrency_replication_multi_stmt_txn --jobs=1|wiredTiger
 concurrency_replication_multi_stmt_txn_ubsan --jobs=1|wiredTiger
 concurrency_replication_ubsan --jobs=1|wiredTiger
 concurrency_replication_wiredtiger_cursor_sweeps --jobs=1|wiredTiger
-concurrency_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
+ concurrency_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
 concurrency_sharded_causal_consistency --jobs=1|wiredTiger
 concurrency_sharded_causal_consistency_and_balancer --jobs=1|wiredTiger
 concurrency_sharded_clusterwide_ops_add_remove_shards --jobs=1|wiredTiger
@@ -82,7 +82,7 @@ concurrency_sharded_with_stepdowns_and_balancer --jobs=1|wiredTiger
 concurrency_simultaneous --jobs=1|wiredTiger
 concurrency_simultaneous_replication --jobs=1|wiredTiger
 concurrency_simultaneous_replication_wiredtiger_cursor_sweeps --jobs=1|wiredTiger
-concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
+ concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|wiredTiger
 core|wiredTiger
  core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command,requires_timeseries|wiredTiger
 core_auth|wiredTiger
@@ -93,7 +93,7 @@ core_txns|wiredTiger
 core_txns_large_txns_format|wiredTiger
 cqf|wiredTiger
 cqf_parallel|wiredTiger
-cst_jscore_passthrough|wiredTiger
+ cst_jscore_passthrough|wiredTiger
 cwrwc_passthrough|wiredTiger
 cwrwc_rc_majority_passthrough|wiredTiger
 cwrwc_wc_majority_passthrough|wiredTiger
@@ -105,12 +105,12 @@ external_auth|wiredTiger|/etc/init.d/slapd start && /etc/init.d/saslauthd start
 external_auth_aws|wiredTiger
 failpoints|wiredTiger
 failpoints_auth|wiredTiger
-feature_flag_multiversion|wiredTiger
+ feature_flag_multiversion|wiredTiger
 fle|wiredTiger
 fle2|wiredTiger
 fle2_query_analysis|wiredTiger
 fle2_sharding|wiredTiger
-free_monitoring|wiredTiger
+ free_monitoring|wiredTiger
 generational_fuzzer|wiredTiger
 generational_fuzzer_replication|wiredTiger
 initial_sync_fuzzer|wiredTiger
@@ -179,7 +179,7 @@ replica_sets --excludeWithAnyTags=featureFlagShardMerge|wiredTiger
 replica_sets_api_version_jscore_passthrough|wiredTiger
 replica_sets_auth --excludeWithAnyTags=featureFlagShardMerge|wiredTiger|/etc/init.d/slapd start && /etc/init.d/saslauthd start
 replica_sets_batched_deletes_passthrough|wiredTiger
-replica_sets_fcbis_jscore_passthrough|wiredTiger
+ replica_sets_fcbis_jscore_passthrough|wiredTiger
 replica_sets_initsync_jscore_passthrough|wiredTiger
 replica_sets_initsync_static_jscore_passthrough|wiredTiger
 replica_sets_jscore_passthrough|wiredTiger
@@ -214,7 +214,7 @@ search_auth|wiredTiger
 search_ssl|wiredTiger
 secondary_reads_passthrough|wiredTiger
 serial_run|wiredTiger
-serverless|wiredTiger
+ serverless|wiredTiger
 server_selection_json_test|wiredTiger
 session_jscore_passthrough|wiredTiger
 sharded_causally_consistent_jscore_passthrough|wiredTiger
@@ -336,7 +336,7 @@ concurrency_replication_multi_stmt_txn --jobs=1|inMemory
 concurrency_replication_multi_stmt_txn_ubsan --jobs=1|inMemory
 concurrency_replication_ubsan --jobs=1|inMemory
 concurrency_replication_wiredtiger_cursor_sweeps --jobs=1|inMemory
-concurrency_replication_wiredtiger_eviction_debug --jobs=1|inMemory
+ concurrency_replication_wiredtiger_eviction_debug --jobs=1|inMemory
 concurrency_sharded_causal_consistency --jobs=1|inMemory
 concurrency_sharded_causal_consistency_and_balancer --jobs=1|inMemory
 concurrency_sharded_clusterwide_ops_add_remove_shards --jobs=1|inMemory
@@ -356,7 +356,7 @@ concurrency_sharded_with_stepdowns_and_balancer --jobs=1|inMemory
 concurrency_simultaneous --jobs=1|inMemory
 concurrency_simultaneous_replication --jobs=1|inMemory
 concurrency_simultaneous_replication_wiredtiger_cursor_sweeps --jobs=1|inMemory
-concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|inMemory
+ concurrency_simultaneous_replication_wiredtiger_eviction_debug --jobs=1|inMemory
 core|inMemory
  core --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command,requires_timeseries|inMemory
 core_auth|inMemory
@@ -367,7 +367,7 @@ core_txns|inMemory
 core_txns_large_txns_format|inMemory
 cqf|inMemory
 cqf_parallel|inMemory
-cst_jscore_passthrough|inMemory
+ cst_jscore_passthrough|inMemory
 cwrwc_passthrough|inMemory
 cwrwc_rc_majority_passthrough|inMemory
 cwrwc_wc_majority_passthrough|inMemory
@@ -379,12 +379,12 @@ ese|inMemory
 external_auth_aws|inMemory
 failpoints|inMemory
 failpoints_auth|inMemory
-feature_flag_multiversion|inMemory
+ feature_flag_multiversion|inMemory
 fle|inMemory
 fle2|inMemory
 fle2_query_analysis|inMemory
 fle2_sharding|inMemory
-free_monitoring|inMemory
+ free_monitoring|inMemory
 generational_fuzzer|inMemory
 generational_fuzzer_replication|inMemory
 initial_sync_fuzzer|inMemory
@@ -436,31 +436,31 @@ multi_shard_multi_stmt_txn_stepdown_primary_jscore_passthrough|inMemory
 multi_stmt_txn_jscore_passthrough_with_migration|inMemory
  multiversion|inMemory|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 5.0 5.3
  multiversion_auth|inMemory|python buildscripts/setup_multiversion_mongodb.py --installDir /data/install --linkDir /data/multiversion --edition base --platform ubuntu1804 --architecture x86_64 5.0 5.3
-no_passthrough|inMemory
-no_passthrough_with_mongod|inMemory
+no_passthrough --jobs=1|inMemory
+no_passthrough_with_mongod --storageEngineCacheSizeGB=10 --jobs=1|inMemory
  no_server|inMemory
 ocsp --jobs=1|inMemory
 parallel --jobs=1|inMemory
  parallel --shellReadMode=legacy --shellWriteMode=compatibility --excludeWithAnyTags=requires_find_command --jobs=1|inMemory
-percona_no_passthrough_with_mongod|inMemory
+percona_no_passthrough_with_mongod --jobs=1|inMemory
 ratelimit|inMemory
 read_concern_linearizable_passthrough|inMemory
 read_concern_majority_passthrough|inMemory
  read_only|inMemory
  read_only_sharded|inMemory
  redaction|inMemory
-replica_sets|inMemory
+replica_sets --excludeWithAnyTags=featureFlagShardMerge|inMemory
 replica_sets_api_version_jscore_passthrough|inMemory
-replica_sets_auth|inMemory|/etc/init.d/slapd start && /etc/init.d/saslauthd start
+replica_sets_auth --excludeWithAnyTags=featureFlagShardMerge|inMemory|/etc/init.d/slapd start && /etc/init.d/saslauthd start
 replica_sets_batched_deletes_passthrough|inMemory
-replica_sets_fcbis_jscore_passthrough|inMemory
+ replica_sets_fcbis_jscore_passthrough|inMemory
  replica_sets_initsync_jscore_passthrough|inMemory
  replica_sets_initsync_static_jscore_passthrough|inMemory
 replica_sets_jscore_passthrough|inMemory
  replica_sets_kill_secondaries_jscore_passthrough|inMemory
-replica_sets_large_txns_format|inMemory
+replica_sets_large_txns_format --excludeWithAnyTags=featureFlagShardMerge|inMemory
 replica_sets_large_txns_format_jscore_passthrough|inMemory
-replica_sets_max_mirroring|inMemory
+replica_sets_max_mirroring --excludeWithAnyTags=featureFlagShardMerge|inMemory
 replica_sets_multi_stmt_txn_jscore_passthrough|inMemory
 replica_sets_multi_stmt_txn_kill_primary_jscore_passthrough|inMemory
 replica_sets_multi_stmt_txn_stepdown_jscore_passthrough|inMemory
@@ -470,7 +470,7 @@ replica_sets_reconfig_jscore_stepdown_passthrough|inMemory
  replica_sets_tde_cbc|inMemory
  replica_sets_tde_gcm|inMemory
 replica_sets_terminate_primary_jscore_passthrough|inMemory
-replica_sets_update_v1_oplog|inMemory
+replica_sets_update_v1_oplog --excludeWithAnyTags=featureFlagShardMerge|inMemory
 replica_sets_update_v1_oplog_jscore_passthrough|inMemory
 resharding_fuzzer|inMemory
 resharding_fuzzer_idempotency|inMemory
@@ -488,7 +488,7 @@ search_auth|inMemory
 search_ssl|inMemory
 secondary_reads_passthrough|inMemory
 serial_run|inMemory
-serverless|inMemory
+ serverless|inMemory
 server_selection_json_test|inMemory
 session_jscore_passthrough|inMemory
 sharded_causally_consistent_jscore_passthrough|inMemory


### PR DESCRIPTION
* buildscripts_test - isn't required as it's test for tests
* cst_jscore_passthrough - disable as upstream https://jira.mongodb.org/browse/SERVER-53746
* concurrency_replication_wiredtiger_eviction_debug - for tests mongod isn't built with debug, so suite fails in 100% cases
* concurrency_simultaneous_replication_wiredtiger_eviction_debug - for tests mongod isn't built with debug, so suite fails in 100% cases
* feature_flag_multiversion - should run on build variants that have the featureFlagToaster and featureFlagSpoon feature flags enabled, fails on default upstream build as well https://github.com/percona/percona-server-mongodb/blob/master/buildscripts/resmokeconfig/suites/feature_flag_multiversion.yml#L1-L2
* free_monitoring - free monitoring will be deprecated in April 2023 and decommissioned in August 2023, no sense to run tests https://www.mongodb.com/docs/manual/administration/free-monitoring/

6.0 only
* replica_sets_fcbis_jscore_passthrough - useless according to https://jira.mongodb.org/browse/SERVER-64405, PSMDB doesn't support fcbis yet
* serverless - atlas feature,  fails on upstream build as well
* exclude tests with featureFlagShardMerge tag as it's serverless feature https://jira.mongodb.org/browse/WT-9510