### PR TITLE
Add job-name under instance_tag for psmdb, psmdb-upgrade, psmdb-tarball, psmdb-tarball-upgrade

### DIFF
--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/centos-6/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/centos-6/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/centos-7/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/centos-7/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: true

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/debian-10/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/debian-10/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/debian-11/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/debian-11/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/debian-9/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/debian-9/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/rhel8/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/rhel8/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-xenial/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball-upgrade/molecule/ubuntu-xenial/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/centos-7/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/centos-7/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: true

--- a/psmdb-tarball/psmdb-tarball/molecule/debian-10/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/debian-10/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/debian-11/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/debian-11/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/rhel8/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/rhel8/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/rhel9/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/rhel9/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/ubuntu-bionic/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/ubuntu-bionic/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/ubuntu-focal/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/ubuntu-focal/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb-tarball/psmdb-tarball/molecule/ubuntu-jammy/molecule.yml
+++ b/psmdb-tarball/psmdb-tarball/molecule/ubuntu-jammy/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/centos-6/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/centos-6/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/centos-7/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/centos-7/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: true

--- a/psmdb/psmdb-upgrade/molecule/debian-10/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/debian-10/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/debian-11/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/debian-11/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/debian-9/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/debian-9/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/rhel8/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/rhel8/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb-upgrade/molecule/ubuntu-xenial/molecule.yml
+++ b/psmdb/psmdb-upgrade/molecule/ubuntu-xenial/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/centos-6/molecule.yml
+++ b/psmdb/psmdb/molecule/centos-6/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/centos-7/molecule.yml
+++ b/psmdb/psmdb/molecule/centos-7/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: true

--- a/psmdb/psmdb/molecule/debian-10/molecule.yml
+++ b/psmdb/psmdb/molecule/debian-10/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/debian-11/molecule.yml
+++ b/psmdb/psmdb/molecule/debian-11/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/debian-9/molecule.yml
+++ b/psmdb/psmdb/molecule/debian-9/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/rhel8-arm/molecule.yml
+++ b/psmdb/psmdb/molecule/rhel8-arm/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/rhel8/molecule.yml
+++ b/psmdb/psmdb/molecule/rhel8/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/rhel9/molecule.yml
+++ b/psmdb/psmdb/molecule/rhel9/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/ubuntu-bionic/molecule.yml
+++ b/psmdb/psmdb/molecule/ubuntu-bionic/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/ubuntu-focal/molecule.yml
+++ b/psmdb/psmdb/molecule/ubuntu-focal/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/ubuntu-jammy/molecule.yml
+++ b/psmdb/psmdb/molecule/ubuntu-jammy/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True

--- a/psmdb/psmdb/molecule/ubuntu-xenial/molecule.yml
+++ b/psmdb/psmdb/molecule/ubuntu-xenial/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-psmdb-worker
+      job-name: ${JOB_NAME}
 provisioner:
   name: ansible
   log: True


### PR DESCRIPTION
This PR is regarding addition of job-name under the instance_tag for the psmdb molecule tests, To identify the instances and jenkins jobs easily from the aws console.