### PR TITLE
PSMDB fix cert's generation for pykmip server

### DIFF
--- a/roles/kmip/tasks/main.yml
+++ b/roles/kmip/tasks/main.yml
@@ -10,6 +10,8 @@
   git:
     repo: 'https://github.com/OpenVPN/easy-rsa.git'
     dest: /pykmip_workdir/easy-rsa
+#    single_branch: yes
+#    version: v3.1.7
 
 - name: Download PyKMIP
   git:
@@ -21,7 +23,7 @@
     cd /pykmip_workdir/easy-rsa
     [ -d pki ] || easyrsa3/easyrsa init-pki
     easyrsa3/easyrsa --req-cn=Percona --batch build-ca nopass
-    easyrsa3/easyrsa --batch build-server-full 127.0.0.1 nopass
+    easyrsa3/easyrsa --req-ou=server --subject-alt-name=DNS:*,IP:127.0.0.1 --batch build-server-full 127.0.0.1 nopass
     easyrsa3/easyrsa --batch build-client-full mongod nopass
     cat pki/issued/mongod.crt pki/private/mongod.key > /pykmip_workdir/mongod.pem
     cp pki/issued/127.0.0.1.crt pki/private/127.0.0.1.key pki/ca.crt /pykmip_workdir/


### PR DESCRIPTION
EasyRSA does not create default server's SAN automatically, we should define it manually