### PR TITLE
PML. Add tests for collmod and rename + extra fixes

### DIFF
--- a/mlink/data_generator.py
+++ b/mlink/data_generator.py
@@ -51,9 +51,9 @@ def stop_all_crud_operations():
     for db_name, stop_event in stop_operations_map.items():
         stop_event.set()
 
-def generate_dummy_data(connection_string, db_name="dummy", num_collections=5, doc_size=150000, batch_size=1000, stop_event=None):
+def generate_dummy_data(connection_string, db_name="dummy", num_collections=5, doc_size=150000, batch_size=10000, stop_event=None):
     """
-    With default parameters generates ~500MB of data within 1 minute.
+    With default parameters generates ~500MB of data within 10 seconds
     If stop_event is provided, it can be used to stop generation early.
     """
 
@@ -65,19 +65,14 @@ def generate_dummy_data(connection_string, db_name="dummy", num_collections=5, d
 
     collections = [f"collection_{i}" for i in range(num_collections)]
 
-    def random_document():
-        return {
-            "_id": ObjectId(),
-            "int": random.randint(0, 10**6),
-            "float": random.uniform(0, 10**6),
-            "string": "".join(random.choices(string.ascii_letters + string.digits, k=200)),
-            "uuid": uuid.uuid4().hex,
-            "binary": Binary(random.randbytes(200)),
-            "decimal": Decimal128(str(random.uniform(0, 10**6))),
-            "timestamp": datetime.datetime.now(datetime.timezone.utc),
-            "array": [random.randint(0, 100) for _ in range(20)],
-            "object": {"nested_key": "".join(random.choices(string.ascii_letters, k=50))},
-        }
+    template_doc = {
+        "int": 42,
+        "float": 3.14159,
+        "string": "x" * 100,
+        "padding1": "a" * 500,
+        "padding2": "b" * 200,
+        "array": [1] * 40,
+    }
 
     for coll_name in collections:
         if stop_event and stop_event.is_set():
@@ -87,5 +82,6 @@ def generate_dummy_data(connection_string, db_name="dummy", num_collections=5, d
         for _ in range(doc_size // batch_size):
             if stop_event and stop_event.is_set():
                 break
-            collection.insert_many([random_document() for _ in range(batch_size)])
+            docs = [{**template_doc, "_id": ObjectId()} for _ in range(batch_size)]
+            collection.insert_many(docs, ordered=False, bypass_document_validation=True)
     Cluster.log("Dummy data generation is completed")

--- a/mlink/mongolink.py
+++ b/mlink/mongolink.py
@@ -24,7 +24,7 @@ class Mongolink:
         container = client.containers.get(self.name)
         return container
 
-    def create(self):
+    def create(self, log_level="debug", extra_args=""):
         try:
             existing_container = self.container
             Cluster.log(f"Removing existing mlink container '{self.name}'...")
@@ -34,12 +34,14 @@ class Mongolink:
 
         Cluster.log(f"Starting mlink to sync from '{self.src}' → '{self.dst}'...")
         client = docker.from_env()
+
+        cmd = f"percona-mongolink --source {self.src} --target {self.dst} --log-level={log_level} --no-color {extra_args}".strip()
         container = client.containers.run(
             image=self.mlink_image,
             name=self.name,
             detach=True,
             network="test",
-            command=f"percona-mongolink --source {self.src} --target {self.dst} --log-level=trace --no-color"
+            command=cmd
         )
         Cluster.log(f"Mlink '{self.name}' started successfully")
 
@@ -148,8 +150,13 @@ class Mongolink:
 
     def logs(self):
         try:
-            logs = self.container.logs(tail=50).decode("utf-8").strip()
-            return logs if logs else "No logs found."
+            raw_logs = self.container.logs().decode("utf-8").strip()
+            filtered_lines = [
+                line for line in raw_logs.splitlines()
+                if "GET /status" not in line
+            ]
+            last_50_logs = "\n".join(filtered_lines[-50:])
+            return last_50_logs if last_50_logs else "No logs found"
 
         except docker.errors.NotFound:
             return "Error: mlink container not found."
@@ -165,12 +172,14 @@ class Mongolink:
         except Exception as e:
             return f"Error fetching logs: {e}"
 
+        ansi_escape_re = re.compile(r"\x1b\[[0-9;]*m")
         error_pattern = re.compile(r"\b(ERROR|error|ERR|err)\b")
-        errors_found = [line for line in logs.split("\n") if error_pattern.search(line)]
+        clean_lines = [ansi_escape_re.sub("", line) for line in logs.split("\n")]
+        errors_found = [line for line in clean_lines if error_pattern.search(line)]
 
         return not bool(errors_found), errors_found
 
-    def wait_for_zero_lag(self, timeout=200, interval=1):
+    def wait_for_zero_lag(self, timeout=120, interval=1):
         start_time = time.time()
 
         try:
@@ -212,7 +221,7 @@ class Mongolink:
                 return False
 
             if last_ts >= cluster_time:
-                Cluster.log(f"Src and dst clusters are in sync, last replicated TS {last_ts} >= current cluster time {cluster_time}")
+                Cluster.log(f"Src and dst are in sync: last repl TS {last_ts} >= cluster time {cluster_time}")
                 return True
 
             time.sleep(interval)
@@ -220,7 +229,7 @@ class Mongolink:
         Cluster.log("Error: Timeout reached while waiting for replication to catch up")
         return False
 
-    def wait_for_repl_stage(self, timeout=200, interval=1):
+    def wait_for_repl_stage(self, timeout=60, interval=1):
         start_time = time.time()
 
         while time.time() - start_time < timeout:

--- a/mlink/test_ddl_extra_sync_rs.py
+++ b/mlink/test_ddl_extra_sync_rs.py
@@ -1,0 +1,664 @@
+import pytest
+import pymongo
+import time
+import docker
+import threading
+import datetime
+from pymongo.errors import OperationFailure
+
+from cluster import Cluster
+from mongolink import Mongolink
+from data_generator import create_all_types_db, generate_dummy_data, stop_all_crud_operations
+from data_integrity_check import compare_data_rs
+
+
+@pytest.fixture(scope="package")
+def docker_client():
+    return docker.from_env()
+
+@pytest.fixture(scope="package")
+def dstRS():
+    return Cluster({ "_id": "rs2", "members": [{"host":"rs201"}]})
+
+@pytest.fixture(scope="package")
+def srcRS():
+    return Cluster({ "_id": "rs1", "members": [{"host":"rs101"}]})
+
+@pytest.fixture(scope="package")
+def mlink(srcRS,dstRS):
+    return Mongolink('mlink',srcRS.mlink_connection, dstRS.mlink_connection)
+
+@pytest.fixture(scope="package")
+def start_cluster(srcRS, dstRS, mlink, request):
+    try:
+        srcRS.destroy()
+        dstRS.destroy()
+        srcRS.create()
+        dstRS.create()
+        yield True
+
+    finally:
+        if request.config.getoption("--verbose"):
+            logs = mlink.logs()
+            print(f"\n\nmlink Last 50 Logs for mlink:\n{logs}\n\n")
+        srcRS.destroy()
+        dstRS.destroy()
+        mlink.destroy()
+
+@pytest.fixture(scope="function")
+def reset_state(srcRS, dstRS, mlink, request):
+    src_client = pymongo.MongoClient(srcRS.connection)
+    dst_client = pymongo.MongoClient(dstRS.connection)
+    if request.config.getoption("--verbose"):
+        logs = mlink.logs()
+        print(f"\n\nmlink Last 50 Logs for mlink:\n{logs}\n\n")
+    mlink.destroy()
+    for db_name in src_client.list_database_names():
+        if db_name not in {"admin", "local", "config"}:
+            src_client.drop_database(db_name)
+    for db_name in dst_client.list_database_names():
+        if db_name not in {"admin", "local", "config"}:
+            dst_client.drop_database(db_name)
+    mlink.create()
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T14(reset_state, srcRS, dstRS, mlink):
+    """
+    Test collMod on collection with validator, validatorLevel, validatorAction
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        db_name = "test_db"
+        coll_name = "test_collection"
+        src[db_name].create_collection(
+            coll_name,
+            validator={"age": {"$gte": 18}},
+            validationAction="warn",
+            validationLevel="moderate"
+        )
+        src[db_name][coll_name].insert_one({"name": "Alice", "age": 30})
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+
+        res = src[db_name].command(
+            "collMod",
+            coll_name,
+            validator={"age": {"$gte": 21}},
+            validationAction="error",
+            validationLevel="strict"
+        )
+        assert res.get("ok") == 1.0, f"collMod failed: {res}"
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to finish init sync"
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    expected_mismatches = [("test_db.test_collection", "options mismatch")]
+    result, summary = compare_data_rs(srcRS, dstRS)
+
+    if not result:
+        unexpected = [m for m in summary if m not in expected_mismatches]
+        missing_expected = [m for m in expected_mismatches if m not in summary]
+
+        if unexpected:
+            assert False, f"Unexpected mismatches: {unexpected}"
+        if not missing_expected:
+            pytest.xfail("Known issue: PML-80")
+        else:
+            assert False, f"Expected mismatches missing: {missing_expected}"
+    pytest.fail("Unexpected pass: test should have failed due to PML-80")
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T15(reset_state, srcRS, dstRS, mlink):
+    """
+    Test collMod on collection with changeStreamPreAndPostImages
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        db_name = "test_db"
+        coll_name1 = "test_collection1"
+        coll_name2 = "test_collection2"
+        src[db_name].create_collection(coll_name1)
+        src[db_name].create_collection(coll_name2, changeStreamPreAndPostImages={"enabled": True})
+        src[db_name][coll_name1].insert_one({"name": "Alice", "age": 30})
+        src[db_name][coll_name2].insert_one({"name": "Alice", "age": 30})
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+
+        res = src[db_name].command(
+            "collMod",
+            coll_name1,
+            changeStreamPreAndPostImages={"enabled": True})
+        assert res.get("ok") == 1.0, f"collMod failed: {res}"
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to finish init sync"
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    expected_mismatches = [
+        ("test_db.test_collection1", "options mismatch"),
+        ("test_db.test_collection2", "options mismatch")
+    ]
+    result, summary = compare_data_rs(srcRS, dstRS)
+
+    if not result:
+        unexpected = [m for m in summary if m not in expected_mismatches]
+        missing_expected = [m for m in expected_mismatches if m not in summary]
+
+        if unexpected:
+            assert False, f"Unexpected mismatches: {unexpected}"
+        if not missing_expected:
+            pytest.xfail("Known issue: PML-79")
+        else:
+            assert False, f"Expected mismatches missing: {missing_expected}"
+    pytest.fail("Unexpected pass: test should have failed due to PML-79")
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T16(reset_state, srcRS, dstRS, mlink):
+    """
+    Test collMod on view
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        db_name = "test_db"
+        coll_name1, coll_name2 = "test_collection1", "test_collection2"
+        view_name = "test_view"
+        src[db_name][coll_name1].insert_many([
+            {"user": "alice1", "status": "Q", "description": "Queued"},
+            {"user": "bob1", "status": "D", "description": "Done"}])
+        src[db_name][coll_name2].insert_many([
+            {"user": "alice2", "status": "Q", "description": "Queued"},
+            {"user": "bob2", "status": "D", "description": "Done"}])
+        src[db_name].command({
+            "create": view_name,
+            "viewOn": coll_name1,
+            "pipeline": [
+                {"$match": {"status": "Q"}},
+                {"$project": {"user": 1, "description": 1, "_id": 0}}]})
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+
+        res = src[db_name].command(
+        "collMod",
+        view_name,
+        viewOn=coll_name2,
+        pipeline=[
+            {"$match": {"status": "D"}},
+            {"$project": {"user": 1, "description": 1, "_id": 0}}])
+        assert res.get("ok") == 1.0, f"collMod failed on view: {res}"
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to finish init sync"
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    dst_view_docs = list(dst[db_name][view_name].find({}))
+    assert dst_view_docs == [{"user": "bob2", "description": "Done"}], f"View data mismatch: {dst_view_docs}"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T17(reset_state, srcRS, dstRS, mlink):
+    """
+    Test collMod on capped collection
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        db_name = "test_db"
+        coll_name = "test_collection"
+        src[db_name].create_collection(coll_name, capped=True, size=1024 * 1024, max=1000)
+        src[db_name][coll_name].insert_one({"x": 1})
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+
+        res = src[db_name].command(
+        "collMod",
+        coll_name,
+        cappedSize=512 * 1024,
+        cappedMax=500)
+        assert res.get("ok") == 1.0, f"collMod failed: {res}"
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to finish init sync"
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    cursor = list(dst[db_name].list_collections(filter={"name": coll_name}))
+    assert cursor, f"Collection '{coll_name}' not found in destination"
+
+    dst_opts = cursor[0].get("options", {})
+    assert dst_opts.get("capped") is True
+    assert dst_opts.get("size") <= 512 * 1024
+    assert dst_opts.get("max") == 500
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T18(reset_state, srcRS, dstRS, mlink):
+    """
+    Test collMod on indexes: TTL, hidden, prepareUnique, unique, name, keyPattern
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        db_name = "test_db"
+        coll_name = "test_collection"
+        coll = src[db_name][coll_name]
+        coll.insert_many([{"createdAt": datetime.datetime.now(datetime.timezone.utc), "a": i, "b": i, "c": -i, "d": i}
+                          for i in range(5)])
+
+        coll.create_index("createdAt", expireAfterSeconds=60)
+        coll.create_index([("a", 1), ("b", -1)], name="ab_index")
+        coll.create_index("c")
+        coll.create_index("d")
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+
+        # Modify TTL
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"createdAt": 1}, "expireAfterSeconds": 120})
+        assert res.get("ok") == 1.0
+
+        # Hide /unhide index by keyPattern / name
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"c": 1}, "hidden": True})
+        assert res.get("ok") == 1.0
+        res = src[db_name].command("collMod", coll_name, index={"name": "ab_index", "hidden": True})
+        assert res.get("ok") == 1.0
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"c": 1}, "hidden": False})
+        assert res.get("ok") == 1.0
+
+        # PrepareUnique and dry run for unique
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"d": 1}, "prepareUnique": True})
+        assert res.get("ok") == 1.0
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"d": 1}, "unique": True}, dryRun=True)
+        assert res.get("ok") == 1.0
+
+        # Prepare unique and convert to unique
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"c": 1}, "prepareUnique": True})
+        assert res.get("ok") == 1.0
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"c": 1}, "unique": True})
+        assert res.get("ok") == 1.0
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to finish init sync"
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    time.sleep(1)
+    index_docs = list(dst[db_name][coll_name].list_indexes())
+    index_by_name = {idx["name"]: idx for idx in index_docs}
+    assert index_by_name["createdAt_1"].get("expireAfterSeconds") == 120
+    assert index_by_name["c_1"].get("unique") is True
+    assert index_by_name["c_1"].get("hidden") is None
+    assert index_by_name["ab_index"].get("hidden") is True
+    assert index_by_name["d_1"].get("prepareUnique") is True
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T19(reset_state, srcRS, dstRS, mlink):
+    """
+    Test collmod when converting to unique fails
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        db_name = "test_db"
+        coll_name = "test_collection"
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        src[db_name][coll_name].insert_many([
+            {"x": 1},
+            {"x": 1},
+            {"x": 2}
+        ])
+        src[db_name][coll_name].create_index("x")
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+
+        res = src[db_name].command("collMod", coll_name, index={"keyPattern": {"x": 1}, "prepareUnique": True})
+        assert res.get("ok") == 1.0
+        try:
+            res = src[db_name].command(
+                "collMod", coll_name,
+                index={"keyPattern": {"x": 1}, "unique": True})
+            assert False, "unique: true should fail due to duplicate values"
+        except pymongo.errors.OperationFailure as e:
+            code_name = e.details.get("codeName") if e.details else None
+            assert code_name == "CannotConvertIndexToUnique", f"Unexpected codeName: {code_name}"
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to finish init sync"
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    time.sleep(1)
+    index_docs = list(dst[db_name][coll_name].list_indexes())
+    idx = next(i for i in index_docs if i["name"] == "x_1")
+    assert idx.get("unique") is not True, "Unique index should not be applied on destination"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T20(reset_state, srcRS, dstRS, mlink):
+    """
+    Test to check renameCollection while collection is being cloned
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        db_name = "test_db"
+        old_name = "collection_4"
+        new_name = "renamed_collection_4"
+        generate_dummy_data(srcRS.connection, db_name)
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+
+        def start_mlink():
+            result = mlink.start()
+            assert result is True, "Failed to start mlink service"
+        def rename_collection():
+            time.sleep(2)
+            res = src.admin.command("renameCollection", f"{db_name}.{old_name}", to=f"{db_name}.{new_name}")
+            assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+
+        t1 = threading.Thread(target=start_mlink)
+        t2 = threading.Thread(target=rename_collection)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage(timeout=30)
+    if not result:
+        if "collection renamed" in mlink.logs():
+                pytest.xfail("Known issue: PML-109")
+        else:
+            assert False, "Failed to start replication stage"
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    time.sleep(1)
+    dst_collections = dst[db_name].list_collection_names()
+    assert new_name in dst_collections, "Renamed collection not found on destination"
+    assert old_name not in dst_collections, "Old collection name still exists on destination"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+    pytest.fail("Unexpected pass: test should have failed due to PML-109")
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T21(reset_state, srcRS, dstRS, mlink):
+    """
+    Test to check renameCollection during data clone
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        generate_dummy_data(srcRS.connection, "dummy")
+
+        db_name1, db_name2 = "test_db1", "test_db2"
+        old_name1, old_name2, old_name3  = "test_collection1", "test_collection2", "test_collection3"
+        new_name1, new_name2, new_name3 = "renamed_collection1", "renamed_collection2", "renamed_collection3"
+        initial_docs_1 = [{"_id": i, "value": f"doc{i}", "email": f"user{i}@test.com", "field": i} for i in range(10)]
+        initial_docs_2 = [{"_id": i, "value": f"doc{i}", "email_new": f"user{i}@test.com", "field": i} for i in range(10)]
+        for coll_name in [old_name1, old_name2, old_name3]:
+            src[db_name1][coll_name].insert_many(initial_docs_1)
+        src[db_name1][new_name2].insert_many(initial_docs_2)
+
+        def start_mlink():
+            result = mlink.start()
+            assert result is True, "Failed to start mlink service"
+        def rename_collection():
+            time.sleep(0.1)
+            res = src.admin.command("renameCollection", f"{db_name1}.{old_name1}", to=f"{db_name1}.{new_name1}")
+            assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+            res = src.admin.command("renameCollection", f"{db_name1}.{old_name2}", to=f"{db_name1}.{new_name2}", dropTarget=True)
+            assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+            res = src.admin.command("renameCollection", f"{db_name1}.{old_name3}", to=f"{db_name2}.{new_name3}")
+            assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+
+        t1 = threading.Thread(target=start_mlink)
+        t2 = threading.Thread(target=rename_collection)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        if "operation_threads_1" in locals():
+            for thread in operation_threads_1:
+                thread.join()
+
+    result = mlink.wait_for_repl_stage(timeout=30)
+    if not result:
+        if "collection renamed" in mlink.logs():
+                pytest.xfail("Known issue: PML-110")
+        else:
+            assert False, "Failed to start replication stage"
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    time.sleep(1)
+    expected_mismatches = [
+        ("test_db1", "hash mismatch"),
+        ("test_db1.renamed_collection1", "hash mismatch"),
+        ("test_db1.renamed_collection2", "hash mismatch"),
+        ("test_db1.renamed_collection1", "record count mismatch"),
+        ("test_db1.renamed_collection2", "record count mismatch")]
+
+    result, summary = compare_data_rs(srcRS, dstRS)
+    if not result:
+        unexpected = [m for m in summary if m not in expected_mismatches]
+        missing_expected = [m for m in expected_mismatches if m not in summary]
+        if missing_expected:
+            assert False, f"Expected mismatches missing: {missing_expected}"
+        if not unexpected:
+            pytest.xfail("Known issue: PML-110")
+        assert False, f"Unexpected mismatches found: {unexpected}"
+
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    expected_error = "catalog:rename"
+    if not mlink_error:
+        has_expected = any(expected_error in line for line in error_logs)
+        unexpected = [line for line in error_logs if expected_error not in line]
+
+        if unexpected:
+            pytest.fail("Unexpected error(s) in logs:\n" + "\n".join(unexpected))
+        elif has_expected:
+            pytest.xfail(f"Expected fail: {expected_error}, no errors should be returned")
+    else:
+        pytest.fail("Unexpected pass: test should have failed due to PML-110")
+
+@pytest.mark.timeout(300,func_only=True)
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T22(reset_state, srcRS, dstRS, mlink):
+    """
+    Test to check renameCollection during repl stage
+    """
+    try:
+        src = pymongo.MongoClient(srcRS.connection)
+        dst = pymongo.MongoClient(dstRS.connection)
+
+        init_test_db, operation_threads_1 = create_all_types_db(srcRS.connection, "init_test_db", start_crud=True)
+        db_name1, db_name2 = "test_db1", "test_db2"
+        old_name1, old_name2, old_name3  = "test_collection1", "test_collection2", "test_collection3"
+        new_name1, new_name2, new_name3 = "renamed_collection1", "renamed_collection2", "renamed_collection3"
+        initial_docs = [{"_id": i, "value": f"doc{i}", "email": f"user{i}@test.com", "field": i} for i in range(10)]
+        collection_names = [old_name1, old_name2, old_name3, new_name2]
+        for coll_name in collection_names:
+            src[db_name1][coll_name].insert_many(initial_docs)
+        src[db_name1][new_name2].create_index("email", unique=True, name="email_unique22")
+        src[db_name1][old_name3].create_index("email", unique=True, name="email_unique31")
+
+        result = mlink.start()
+        assert result is True, "Failed to start mlink service"
+        result = mlink.wait_for_repl_stage()
+        assert result is True, "Failed to finish init sync"
+
+        repl_test_db, operation_threads_2 = create_all_types_db(srcRS.connection, "repl_test_db", start_crud=True)
+        res = src.admin.command("renameCollection", f"{db_name1}.{old_name1}", to=f"{db_name1}.{new_name1}")
+        assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+        res = src.admin.command("renameCollection", f"{db_name1}.{old_name2}", to=f"{db_name1}.{new_name2}", dropTarget=True)
+        assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+        res = src.admin.command("renameCollection", f"{db_name1}.{old_name3}", to=f"{db_name2}.{new_name3}")
+        assert res.get("ok") == 1.0, f"renameCollection failed: {res}"
+
+    except Exception as e:
+        raise
+    finally:
+        stop_all_crud_operations()
+        all_threads = []
+        if "operation_threads_1" in locals():
+            all_threads += operation_threads_1
+        if "operation_threads_2" in locals():
+            all_threads += operation_threads_2
+        for thread in all_threads:
+            thread.join()
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    time.sleep(1)
+    dst_collections1 = set(dst[db_name1].list_collection_names())
+    dst_collections2 = set(dst[db_name2].list_collection_names())
+    for name in [new_name1, new_name2]:
+        assert name in dst_collections1, f"Expected collection '{name}' not found in {db_name1}"
+    for name in [old_name1, old_name2, old_name3]:
+        assert name not in dst_collections1, f"Old collection '{name}' still exists in {db_name1}"
+    assert new_name3 in dst_collections2, f"Renamed collection '{new_name3}' not found in {db_name2}"
+
+    result, summary = compare_data_rs(srcRS, dstRS)
+    if not result:
+        unexpected_mismatch_types = {"hash mismatch", "record count mismatch", "options mismatch"}
+        if all(m[1] not in unexpected_mismatch_types for m in summary):
+            pytest.xfail("Known issue: PML-111")
+        assert False, f"Unexpected mismatch types found: {summary}"
+
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+    pytest.fail("Unexpected pass: test should have failed due to PML-111")

--- a/mlink/test_transactions_rs.py
+++ b/mlink/test_transactions_rs.py
@@ -45,10 +45,12 @@ def start_cluster(srcRS, dstRS, mlink, request):
         mlink.destroy()
 
 @pytest.fixture(scope="function")
-def reset_state(srcRS, dstRS, mlink):
+def reset_state(srcRS, dstRS, mlink, request):
     src_client = pymongo.MongoClient(srcRS.connection)
     dst_client = pymongo.MongoClient(dstRS.connection)
-
+    if request.config.getoption("--verbose"):
+        logs = mlink.logs()
+        print(f"\n\nmlink Last 50 Logs for mlink:\n{logs}\n\n")
     mlink.destroy()
     for db_name in src_client.list_database_names():
         if db_name not in {"admin", "local", "config"}:
@@ -178,6 +180,175 @@ def test_rs_mlink_PML_T8(reset_state, srcRS, dstRS, mlink):
 @pytest.mark.usefixtures("start_cluster")
 def test_rs_mlink_PML_T9(reset_state, srcRS, dstRS, mlink):
     """
+    Test for two concurrent transactions modifying the same document
+    """
+    src = pymongo.MongoClient(srcRS.connection)
+    dst = pymongo.MongoClient(dstRS.connection)
+
+    result = mlink.start()
+    assert result is True, "Failed to start mlink service"
+
+    with src.start_session() as session1, src.start_session() as session2:
+        perform_transaction(src, session1, "conflict_db", "test_coll", [{"_id": 1, "value": "txn1"}], commit=False)
+        perform_transaction(src, session2, "conflict_db", "test_coll", [{"_id": 1, "value": "txn2"}], commit=False)
+
+        session1.commit_transaction()
+        try:
+            session2.commit_transaction()
+            assert False, "Write conflict transaction should not have committed"
+        except OperationFailure:
+            pass
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    actual_doc = dst["conflict_db"]["test_coll"].find_one({"_id": 1})
+    expected_doc = {"_id": 1, "value": "txn1"}
+
+    assert actual_doc is not None, "Expected document is missing from destination"
+    assert actual_doc == expected_doc, f"Document in destination does not match expected: {actual_doc}"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T10(reset_state, srcRS, dstRS, mlink):
+    """
+    MongoDB creates as many oplog entries as necessary to the encapsulate all write operations in a transaction,
+    instead of a single entry for all write operations in the transaction. This removes the 16MB total size limit
+    for a transaction imposed by the single oplog entry for all its write operations. Although the total size limit
+    is removed, each oplog entry still must be within the BSON document size limit of 16MB.
+    """
+    src = pymongo.MongoClient(srcRS.connection)
+    dst = pymongo.MongoClient(dstRS.connection)
+
+    result = mlink.start()
+    assert result is True, "Failed to start mlink service"
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to start replication stage"
+
+    large_docs = [{"_id": i, "name": "Large Document Test", "value": "x" * 16777160} for i in range(10)]
+
+    with src.start_session() as session:
+        session.start_transaction()
+        src["large_txn_db"]["test_coll"].insert_many(large_docs, session=session)
+        session.commit_transaction()
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    docs_in_dst = {doc["_id"]: doc for doc in dst["large_txn_db"]["test_coll"].find({})}
+    missing_docs = [doc["_id"] for doc in large_docs if doc["_id"] not in docs_in_dst]
+    mismatched_docs = [doc["_id"] for doc in large_docs if docs_in_dst.get(doc["_id"]) != doc]
+
+    assert not missing_docs, f"Missing documents in destination: {missing_docs}"
+    assert not mismatched_docs, f"Document mismatch in destination: {mismatched_docs}"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T11(reset_state, srcRS, dstRS, mlink):
+    """
+    Test for transaction with multiple collections
+    """
+    src = pymongo.MongoClient(srcRS.connection)
+    dst = pymongo.MongoClient(dstRS.connection)
+
+    result = mlink.start()
+    assert result is True, "Failed to start mlink service"
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to start replication stage"
+
+    large_docs = [{"_id": i, "value": f"doc_{i}"} for i in range(2000)]
+
+    with src.start_session() as session:
+        session.start_transaction()
+        src["large_txn_db1"]["test_coll1"].insert_many(large_docs, session=session)
+        src["large_txn_db2"]["test_coll2"].insert_many(large_docs, session=session)
+        src["large_txn_db3"]["test_coll3"].insert_many(large_docs, session=session)
+        session.commit_transaction()
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    dst_dbs = ["large_txn_db1", "large_txn_db2", "large_txn_db3"]
+    collections = ["test_coll1", "test_coll2", "test_coll3"]
+    for db_name, coll_name in zip(dst_dbs, collections):
+        dst_coll = dst[db_name][coll_name]
+        docs_in_dst = {doc["_id"]: doc for doc in dst_coll.find({})}
+        missing_docs = [doc for doc in large_docs if doc["_id"] not in docs_in_dst]
+        mismatched_docs = [doc for doc in large_docs if docs_in_dst.get(doc["_id"]) != doc]
+
+        assert not missing_docs, f"Missing documents in {db_name}.{coll_name}: {missing_docs}"
+        assert not mismatched_docs, f"Document mismatch in {db_name}.{coll_name}: {mismatched_docs}"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+    mlink_error, error_logs = mlink.check_mlink_errors()
+    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
+
+
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T12(reset_state, srcRS, dstRS, mlink):
+    """
+    Test to verify transaction replication if mlink service is restarted
+    """
+    src = pymongo.MongoClient(srcRS.connection)
+    dst = pymongo.MongoClient(dstRS.connection)
+
+    result = mlink.start()
+    assert result is True, "Failed to start mlink service"
+    result = mlink.wait_for_repl_stage()
+    assert result is True, "Failed to start replication stage"
+    result = mlink.wait_for_checkpoint()
+    assert result is True, "Mongolink failed to save checkpoint"
+
+    with src.start_session() as session1, src.start_session() as session2:
+        session1.start_transaction()
+        session2.start_transaction()
+
+        src["test_db"]["test_coll"].insert_one({"_id": 1, "value": "test1"}, session=session1)
+        src["test_db"]["test_coll"].insert_one({"_id": 2, "value": "test2"}, session=session2)
+
+        mlink.restart()
+
+        session1.commit_transaction()
+        session2.abort_transaction()
+
+    result = mlink.wait_for_zero_lag()
+    assert result is True, "Failed to catch up on replication"
+
+    result = mlink.finalize()
+    assert result is True, "Failed to finalize mlink service"
+
+    docs_in_dst = {doc["_id"]: doc for doc in dst["test_db"]["test_coll"].find({})}
+    expected_doc = {"_id": 1, "value": "test1"}
+    unexpected_doc_id = 2
+
+    assert expected_doc["_id"] in docs_in_dst, f"Expected document missing: {expected_doc}"
+    assert docs_in_dst.get(expected_doc["_id"]) == expected_doc, f"Mismatch in expected document: {docs_in_dst.get(expected_doc['_id'])}"
+    assert unexpected_doc_id not in docs_in_dst, f"Unexpected document found: {docs_in_dst.get(unexpected_doc_id)}"
+
+    result, _ = compare_data_rs(srcRS, dstRS)
+    assert result is True, "Data mismatch after synchronization"
+
+@pytest.mark.usefixtures("start_cluster")
+def test_rs_mlink_PML_T13(reset_state, srcRS, dstRS, mlink):
+    """
     Test to simulate oplog rollover during transaction
     """
     src = pymongo.MongoClient(srcRS.connection)
@@ -193,14 +364,14 @@ def test_rs_mlink_PML_T9(reset_state, srcRS, dstRS, mlink):
 
     stop_generation = threading.Event()
     try:
-        dummy_thread = threading.Thread(target=generate_dummy_data,args=(srcRS.connection, "dummy", 20, 150000, 1000, stop_generation))
+        dummy_thread = threading.Thread(target=generate_dummy_data,args=(srcRS.connection, "dummy", 20, 150000, 50, stop_generation))
         dummy_thread.start()
         def keep_transaction_alive(session, db_name, coll_name):
             coll = src[db_name][coll_name]
             while session.in_transaction:
                 try:
                     coll.update_one({"_id": "keep_alive"}, {"$set": {"ts": time.time()}}, upsert=True, session=session)
-                    time.sleep(10)
+                    time.sleep(0.1)
                 except pymongo.errors.PyMongoError:
                     break
         def commit_with_retries(session):
@@ -267,172 +438,3 @@ def test_rs_mlink_PML_T9(reset_state, srcRS, dstRS, mlink):
 
     mlink_error, error_logs = mlink.check_mlink_errors()
     assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
-
-@pytest.mark.usefixtures("start_cluster")
-def test_rs_mlink_PML_T10(reset_state, srcRS, dstRS, mlink):
-    """
-    Test for two concurrent transactions modifying the same document
-    """
-    src = pymongo.MongoClient(srcRS.connection)
-    dst = pymongo.MongoClient(dstRS.connection)
-
-    result = mlink.start()
-    assert result is True, "Failed to start mlink service"
-
-    with src.start_session() as session1, src.start_session() as session2:
-        perform_transaction(src, session1, "conflict_db", "test_coll", [{"_id": 1, "value": "txn1"}], commit=False)
-        perform_transaction(src, session2, "conflict_db", "test_coll", [{"_id": 1, "value": "txn2"}], commit=False)
-
-        session1.commit_transaction()
-        try:
-            session2.commit_transaction()
-            assert False, "Write conflict transaction should not have committed"
-        except OperationFailure:
-            pass
-
-    result = mlink.wait_for_zero_lag()
-    assert result is True, "Failed to catch up on replication"
-
-    result = mlink.finalize()
-    assert result is True, "Failed to finalize mlink service"
-
-    actual_doc = dst["conflict_db"]["test_coll"].find_one({"_id": 1})
-    expected_doc = {"_id": 1, "value": "txn1"}
-
-    assert actual_doc is not None, "Expected document is missing from destination"
-    assert actual_doc == expected_doc, f"Document in destination does not match expected: {actual_doc}"
-
-    result, _ = compare_data_rs(srcRS, dstRS)
-    assert result is True, "Data mismatch after synchronization"
-    mlink_error, error_logs = mlink.check_mlink_errors()
-    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
-
-@pytest.mark.usefixtures("start_cluster")
-def test_rs_mlink_PML_T11(reset_state, srcRS, dstRS, mlink):
-    """
-    MongoDB creates as many oplog entries as necessary to the encapsulate all write operations in a transaction,
-    instead of a single entry for all write operations in the transaction. This removes the 16MB total size limit
-    for a transaction imposed by the single oplog entry for all its write operations. Although the total size limit
-    is removed, each oplog entry still must be within the BSON document size limit of 16MB.
-    """
-    src = pymongo.MongoClient(srcRS.connection)
-    dst = pymongo.MongoClient(dstRS.connection)
-
-    result = mlink.start()
-    assert result is True, "Failed to start mlink service"
-    result = mlink.wait_for_repl_stage()
-    assert result is True, "Failed to start replication stage"
-
-    large_docs = [{"_id": i, "name": "Large Document Test", "value": "x" * 16777160} for i in range(10)]
-
-    with src.start_session() as session:
-        session.start_transaction()
-        src["large_txn_db"]["test_coll"].insert_many(large_docs, session=session)
-        session.commit_transaction()
-
-    result = mlink.wait_for_zero_lag()
-    assert result is True, "Failed to catch up on replication"
-
-    result = mlink.finalize()
-    assert result is True, "Failed to finalize mlink service"
-
-    docs_in_dst = {doc["_id"]: doc for doc in dst["large_txn_db"]["test_coll"].find({})}
-    missing_docs = [doc["_id"] for doc in large_docs if doc["_id"] not in docs_in_dst]
-    mismatched_docs = [doc["_id"] for doc in large_docs if docs_in_dst.get(doc["_id"]) != doc]
-
-    assert not missing_docs, f"Missing documents in destination: {missing_docs}"
-    assert not mismatched_docs, f"Document mismatch in destination: {mismatched_docs}"
-
-    result, _ = compare_data_rs(srcRS, dstRS)
-    assert result is True, "Data mismatch after synchronization"
-    mlink_error, error_logs = mlink.check_mlink_errors()
-    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
-
-@pytest.mark.usefixtures("start_cluster")
-def test_rs_mlink_PML_T12(reset_state, srcRS, dstRS, mlink):
-    """
-    Test for transaction with multiple collections
-    """
-    src = pymongo.MongoClient(srcRS.connection)
-    dst = pymongo.MongoClient(dstRS.connection)
-
-    result = mlink.start()
-    assert result is True, "Failed to start mlink service"
-    result = mlink.wait_for_repl_stage()
-    assert result is True, "Failed to start replication stage"
-
-    large_docs = [{"_id": i, "value": f"doc_{i}"} for i in range(2000)]
-
-    with src.start_session() as session:
-        session.start_transaction()
-        src["large_txn_db1"]["test_coll1"].insert_many(large_docs, session=session)
-        src["large_txn_db2"]["test_coll2"].insert_many(large_docs, session=session)
-        src["large_txn_db3"]["test_coll3"].insert_many(large_docs, session=session)
-        session.commit_transaction()
-
-    result = mlink.wait_for_zero_lag()
-    assert result is True, "Failed to catch up on replication"
-
-    result = mlink.finalize()
-    assert result is True, "Failed to finalize mlink service"
-
-    dst_dbs = ["large_txn_db1", "large_txn_db2", "large_txn_db3"]
-    collections = ["test_coll1", "test_coll2", "test_coll3"]
-    for db_name, coll_name in zip(dst_dbs, collections):
-        dst_coll = dst[db_name][coll_name]
-        docs_in_dst = {doc["_id"]: doc for doc in dst_coll.find({})}
-        missing_docs = [doc for doc in large_docs if doc["_id"] not in docs_in_dst]
-        mismatched_docs = [doc for doc in large_docs if docs_in_dst.get(doc["_id"]) != doc]
-
-        assert not missing_docs, f"Missing documents in {db_name}.{coll_name}: {missing_docs}"
-        assert not mismatched_docs, f"Document mismatch in {db_name}.{coll_name}: {mismatched_docs}"
-
-    result, _ = compare_data_rs(srcRS, dstRS)
-    assert result is True, "Data mismatch after synchronization"
-    mlink_error, error_logs = mlink.check_mlink_errors()
-    assert mlink_error is True, f"Mlink reported errors in logs: {error_logs}"
-
-
-@pytest.mark.usefixtures("start_cluster")
-def test_rs_mlink_PML_T13(reset_state, srcRS, dstRS, mlink):
-    """
-    Test to verify transaction replication if mlink service is restarted
-    """
-    src = pymongo.MongoClient(srcRS.connection)
-    dst = pymongo.MongoClient(dstRS.connection)
-
-    result = mlink.start()
-    assert result is True, "Failed to start mlink service"
-    result = mlink.wait_for_repl_stage()
-    assert result is True, "Failed to start replication stage"
-    result = mlink.wait_for_checkpoint()
-    assert result is True, "Mongolink failed to save checkpoint"
-
-    with src.start_session() as session1, src.start_session() as session2:
-        session1.start_transaction()
-        session2.start_transaction()
-
-        src["test_db"]["test_coll"].insert_one({"_id": 1, "value": "test1"}, session=session1)
-        src["test_db"]["test_coll"].insert_one({"_id": 2, "value": "test2"}, session=session2)
-
-        mlink.restart()
-
-        session1.commit_transaction()
-        session2.abort_transaction()
-
-    result = mlink.wait_for_zero_lag()
-    assert result is True, "Failed to catch up on replication"
-
-    result = mlink.finalize()
-    assert result is True, "Failed to finalize mlink service"
-
-    docs_in_dst = {doc["_id"]: doc for doc in dst["test_db"]["test_coll"].find({})}
-    expected_doc = {"_id": 1, "value": "test1"}
-    unexpected_doc_id = 2
-
-    assert expected_doc["_id"] in docs_in_dst, f"Expected document missing: {expected_doc}"
-    assert docs_in_dst.get(expected_doc["_id"]) == expected_doc, f"Mismatch in expected document: {docs_in_dst.get(expected_doc['_id'])}"
-    assert unexpected_doc_id not in docs_in_dst, f"Unexpected document found: {docs_in_dst.get(unexpected_doc_id)}"
-
-    result, _ = compare_data_rs(srcRS, dstRS)
-    assert result is True, "Data mismatch after synchronization"


### PR DESCRIPTION
- improved dummy_data generation: removed randomization, reduced doc size and increased doc count to maintain overall DB size / generation time
- adjusted check for mlink errors to ignore ASCI color if present
- moved xfail check from decorator into test body to control where failure is triggered
- fixed flaky T6 (db drop and recreation) test