### PR TITLE
PBM replace deprecated mc config command

### DIFF
--- a/pbm-functional/pytest/docker-compose.yaml
+++ b/pbm-functional/pytest/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     command: azurite-blob --blobHost 0.0.0.0 -d /dev/stdout
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: minio/minio
     container_name: minio
     ports:
       - "9000:9000"
@@ -57,13 +57,13 @@ services:
 
   createbucket:
     container_name: createbucket
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: minio/mc
     networks:
       - test
     depends_on:
       - minio
     entrypoint: >
-      /bin/sh -c " sleep 5; /usr/bin/mc config host add myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
+      /bin/sh -c " sleep 5; /usr/bin/mc alias set myminio http://minio:9000 minio1234 minio1234; /usr/bin/mc mb myminio/bcp; exit 0; "
 
   pykmip:
     image: pykmip/local


### PR DESCRIPTION
Replaced deprecated `mc config` command with `mc alias`
See https://github.com/minio/mc/pull/5201 