### PR TITLE
PML-169: Adding token authentication for git function to stop 403

### DIFF
--- a/pml/tests/test_plm.py
+++ b/pml/tests/test_plm.py
@@ -177,8 +177,9 @@ def start_plm_service(host):
     return start_plm
 
 def get_git_commit():
+    headers = {'Authorization': 'token ' + os.environ.get("MONGO_REPO_TOKEN")}
     url = f"https://api.github.com/repos/percona/percona-mongolink/commits/release-{version}"
-    git_commit = requests.get(url)
+    git_commit = requests.get(url, headers=headers)
 
     if git_commit.status_code == 200:
         return git_commit.json()["sha"]


### PR DESCRIPTION
If there are too many attempts to reach the github api too soon a 403 will be returned and block the user from continuing. This will break tests if ran too many times. I have added authentication to stop this from happening in the future.