### PR TITLE
PSMDB-2046 treat empty result as a failure

### DIFF
--- a/regression-tests/build_image/Dockerfile_gcc_from_scratch
+++ b/regression-tests/build_image/Dockerfile_gcc_from_scratch
@@ -155,7 +155,7 @@ CPPPATH = \"/usr/include\"\n\
 LIBPATH = \"/usr/lib /usr/lib64\"\n\
 " > gcc.vars
 ENV MONGO_VERSION=$psm_ver-$psm_release
-ADD https://raw.githubusercontent.com/Percona-QA/psmdb-testing/main/regression-tests/resmoke2junit.py .
+ADD https://raw.githubusercontent.com/Percona-QA/psmdb-testing/refs/heads/main/regression-tests/resmoke2junit.py .
 
 FROM base_image AS psmdb_builder
 ARG build_platform=bazel

--- a/regression-tests/resmoke2junit.py
+++ b/regression-tests/resmoke2junit.py
@@ -36,49 +36,69 @@ def resmoke2junit(skip_long_lines=1):
             if jsonfile.startswith('resmoke') and jsonfile.endswith('.json'):
                 with open(jsonfile) as data_file:
                     data = json.load(data_file)
-                    junitfile.write('\t<testsuite name="{}" failures="{}" tests="{}">\n'.format(jsonfile[8:-7], data['failures'], len(data['results'])))
-
-                    for result in data['results']:
-                        junitfile.write('\t\t<testcase name="{}" time="{}">'.format(result['test_file'], result['elapsed']))
-                        if result['status'] == 'fail':
-                            junitfile.write('\n\t\t\t<failure><![CDATA[\n')
-                            logfile = '{}.log'.format(jsonfile[:-5])
-                            if '/' in result['test_file'][:-3]:
-                                if jsonfile.startswith('resmoke_unittests'):
-                                    test_name = result['test_file'].rsplit('/', 1)[1]
-                                    prefix = '[cpp_unit_test:'
-                                else:
-                                    test_name = result['test_file'][:-3].rsplit('/', 1)[1]
-                                    prefix = '[js_test:'
-                            else:
-                                test_name = result['test_file']
-                                prefix = ''
-
-                            has_error_text = 0
-                            with open(logfile, 'r') as logfile:
+                    suite_name = jsonfile[8:-7]
+                    if len(data['results']) == 0:
+                        logfile = '{}.log'.format(jsonfile[:-5])
+                        junitfile.write('\t<testsuite name="{}" failures="{}" tests="{}">\n'.format(suite_name, 1, 1))
+                        junitfile.write('\t\t<testcase name="{}" time="{}">'.format(suite_name, '0.0'))
+                        junitfile.write('\n\t\t\t<failure><![CDATA[\n')
+                        if os.path.exists(logfile):
+                            with open(logfile, 'r') as log_file:
                                 error_log.clear()
-                                for line in logfile:
-                                    if '{}{}]'.format(prefix, test_name) in line:
-                                        if len(line) >= 2048 and skip_long_lines == 1:
-                                            error_log.append('### Skipped very long line ###\n')
-                                        else:
-                                            line = ''.join(filter(lambda x: 32 <= ord(x) <= 126, line)) + '\n'
-                                            error_log.append(line)
-                                        has_error_text = 1
-
-                            if has_error_text == 0:
-                                junitfile.write('Couldn\'t collect error text from the log file.]]></failure>')
-                            else:
+                                for line in log_file:
+                                    line = ''.join(filter(lambda x: 32 <= ord(x) <= 126, line)) + '\n'
+                                    error_log.append(line)
                                 for err in error_log:
                                     junitfile.write(err)
-
-                                junitfile.write('\t\t\t]]></failure>')
-
-                        if result['status'] != 'pass':
-                            junitfile.write('\n\t\t</testcase>\n')
                         else:
-                            junitfile.write('</testcase>\n')
-                    junitfile.write('\t</testsuite>\n')
+                            junitfile.write('Suite had no test results and no log file was found.')
+                        junitfile.write('\t\t\t]]></failure>')
+                        junitfile.write('\n\t\t</testcase>\n')
+                        junitfile.write('\t</testsuite>\n')
+                    else:
+                        junitfile.write('\t<testsuite name="{}" failures="{}" tests="{}">\n'.format(suite_name, data['failures'], len(data['results'])))
+
+                        for result in data['results']:
+                            junitfile.write('\t\t<testcase name="{}" time="{}">'.format(result['test_file'], result['elapsed']))
+                            if result['status'] == 'fail':
+                                junitfile.write('\n\t\t\t<failure><![CDATA[\n')
+                                logfile = '{}.log'.format(jsonfile[:-5])
+                                if '/' in result['test_file'][:-3]:
+                                    if jsonfile.startswith('resmoke_unittests'):
+                                        test_name = result['test_file'].rsplit('/', 1)[1]
+                                        prefix = '[cpp_unit_test:'
+                                    else:
+                                        test_name = result['test_file'][:-3].rsplit('/', 1)[1]
+                                        prefix = '[js_test:'
+                                else:
+                                    test_name = result['test_file']
+                                    prefix = ''
+
+                                has_error_text = 0
+                                with open(logfile, 'r') as logfile:
+                                    error_log.clear()
+                                    for line in logfile:
+                                        if '{}{}]'.format(prefix, test_name) in line:
+                                            if len(line) >= 2048 and skip_long_lines == 1:
+                                                error_log.append('### Skipped very long line ###\n')
+                                            else:
+                                                line = ''.join(filter(lambda x: 32 <= ord(x) <= 126, line)) + '\n'
+                                                error_log.append(line)
+                                            has_error_text = 1
+
+                                if has_error_text == 0:
+                                    junitfile.write('Couldn\'t collect error text from the log file.]]></failure>')
+                                else:
+                                    for err in error_log:
+                                        junitfile.write(err)
+
+                                    junitfile.write('\t\t\t]]></failure>')
+
+                            if result['status'] != 'pass':
+                                junitfile.write('\n\t\t</testcase>\n')
+                            else:
+                                junitfile.write('</testcase>\n')
+                        junitfile.write('\t</testsuite>\n')
                 continue
             else:
                 continue


### PR DESCRIPTION
This pull request improves the handling of test suite results in the `resmoke2junit.py` script and updates the way the script is referenced in the Dockerfile. The most significant change is better support for test suites that have no results, ensuring that these cases are correctly represented in the generated JUnit XML output.

JUnit output improvements:

* Enhanced the `resmoke2junit.py` script to handle test suites with zero results by generating a failure entry in the JUnit XML, including log file contents if available, or a default message if not. This ensures that empty or failed test suites are clearly reported in CI systems.

Build process update:

* Updated the Dockerfile to fetch the `resmoke2junit.py` script from the correct branch reference (`refs/heads/main`) in the GitHub URL, ensuring that the latest version from the main branch is always used during image builds.