### PR TITLE
PBM-1592 setup with OIDC auth

### DIFF
--- a/pbm-functional/pytest/Dockerfile
+++ b/pbm-functional/pytest/Dockerfile
@@ -68,6 +68,9 @@ RUN echo -e 'vaulttoken' > /etc/vault/token && \
     chown -R mongodb /etc/vault && chmod 400 /etc/vault/token && \
     chown -R mongodb /etc/x509 && chmod 400 /etc/x509/* && \
     chown -R mongodb /etc/nginx-minio && \
+    mkdir -p /etc/pki/ca-trust/source/anchors && \
+    cp /etc/x509/ca.crt /etc/pki/ca-trust/source/anchors/ && \
+    update-ca-trust extract && \
     if [ -f "/usr/bin/mongosh" ] ; then \
         ln -s /usr/bin/mongosh /usr/bin/mongo ; \
     fi && \

--- a/pbm-functional/pytest/Dockerfile-easyrsa
+++ b/pbm-functional/pytest/Dockerfile-easyrsa
@@ -34,3 +34,11 @@ RUN ./easyrsa --req-ou=server --days=90 --subject-alt-name=DNS:nginx-minio --bat
     cp pki/ca.crt /etc/nginx-minio/ && \
     cp pki/issued/nginx-minio.crt /etc/nginx-minio/ && \
     cp pki/private/nginx-minio.key /etc/nginx-minio/
+
+#For keycloak
+RUN ./easyrsa --batch build-server-full keycloak nopass && \
+    mkdir -p /etc/keycloak && \
+    cp pki/ca.crt /etc/keycloak/ && \
+    cat pki/issued/keycloak.crt pki/private/keycloak.key > /etc/keycloak/keycloak.pem && \
+    cp pki/issued/keycloak.crt /etc/keycloak/ && \
+    cp pki/private/keycloak.key /etc/keycloak/

--- a/pbm-functional/pytest/Dockerfile-keycloak
+++ b/pbm-functional/pytest/Dockerfile-keycloak
@@ -1,0 +1,187 @@
+FROM easyrsa/local AS easyrsa
+
+FROM quay.io/keycloak/keycloak:latest
+
+ENV KEYCLOAK_ADMIN=admin
+ENV KEYCLOAK_ADMIN_PASSWORD=admin
+
+COPY --from=easyrsa --chown=keycloak /etc/keycloak/keycloak.crt /opt/keycloak/conf/server.crt.pem
+COPY --from=easyrsa --chown=keycloak /etc/keycloak/keycloak.key /opt/keycloak/conf/server.key.pem
+
+RUN mkdir -p /opt/keycloak/data/import
+RUN cat > /opt/keycloak/data/import/test-realm.json <<'JSON'
+{
+  "realm": "test",
+  "enabled": true,
+  "sslRequired": "external",
+
+  "roles": {
+    "realm": [
+      { "name": "mongodb.readWrite", "description": "Sample realm role for MongoDB access" }
+    ]
+  },
+
+  "groups": [
+    {
+      "name": "testers",
+      "realmRoles": [ "mongodb.readWrite" ]
+    }
+  ],
+
+  "clients": [
+    {
+      "clientId": "test-app",
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost:27097/redirect",
+        "https://localhost:*/*",
+        "https://keycloak:*/*",
+        "*"
+      ],
+      "webOrigins": ["*"],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "attributes": { "pkce.code.challenge.method": "S256" },
+
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "email",
+            "claim.name": "email",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "preferred_username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "access.token.claim": "true",
+            "id.token.claim": "false",
+            "userinfo.token.claim": "false"
+          }
+        }
+      ]
+    },
+
+    {
+      "clientId": "test-confidential",
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "serviceAccountsEnabled": true,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "secret": "test-secret"
+    },
+
+    {
+      "clientId": "pbmclient",
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "serviceAccountsEnabled": true,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "secret": "pbm-secret",
+
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "access.token.claim": "true",
+            "id.token.claim": "false",
+            "userinfo.token.claim": "false",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "access.token.claim": "true",
+            "id.token.claim": "false",
+            "userinfo.token.claim": "false"
+          }
+        }
+      ]
+    }
+  ],
+
+  "users": [
+    {
+      "username": "test",
+      "enabled": true,
+      "email": "test@example.test",
+      "emailVerified": true,
+      "groups": ["testers"],
+      "credentials": [
+        { "type": "password", "value": "testpass", "temporary": false }
+      ]
+    },
+    {
+      "username": "pbmuser",
+      "enabled": true,
+      "email": "pbmuser@example.test",
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "pbmpass", "temporary": false }
+      ]
+    }
+  ]
+}
+JSON
+
+CMD ["start-dev","--https-certificate-file=/opt/keycloak/conf/server.crt.pem","--https-certificate-key-file=/opt/keycloak/conf/server.key.pem","--hostname=keycloak","--hostname-strict=false","--import-realm"]

--- a/pbm-functional/pytest/cluster.py
+++ b/pbm-functional/pytest/cluster.py
@@ -745,6 +745,12 @@ class Cluster:
                          '{"db":"admin","role":"clusterMonitor" },' +
                          '{"db":"admin","role":"restore" },' +
                          '{"db":"admin","role":"pbmAnyAction" }]});\'')
+        oidc_pbm_user = ('\'db.getSiblingDB("$external").runCommand({createUser:"keycloak/pbmclient","roles":[' +
+                         '{"db":"admin","role":"readWrite","collection":""},' +
+                         '{"db":"admin","role":"backup" },' +
+                         '{"db":"admin","role":"clusterMonitor" },' +
+                         '{"db":"admin","role":"restore" },' +
+                         '{"db":"admin","role":"pbmAnyAction" }]});\'')
         logs = primary.check_output(
             "mongo -u root -p root --quiet --eval " + init_pbm_user)
         logs = primary.check_output(
@@ -761,6 +767,10 @@ class Cluster:
         if "authMechanism=PLAIN" in uri:
             logs = primary.check_output(
                 "mongo -u root -p root --quiet --eval " + ldap_mongo_grp)
+            Cluster.log(logs)
+        if "authMechanism=MONGODB-OIDC" in uri:
+            logs = primary.check_output(
+                "mongo -u root -p root --quiet --eval " + oidc_pbm_user)
             Cluster.log(logs)
 
     def __setup_authorizations(self, replicasets):

--- a/pbm-functional/pytest/docker-compose.yaml
+++ b/pbm-functional/pytest/docker-compose.yaml
@@ -138,6 +138,18 @@ services:
     networks:
       - test
 
+  keycloak:
+    image: keycloak/local
+    build:
+      dockerfile: ./Dockerfile-keycloak
+      context: .
+    container_name: keycloak
+    hostname: keycloak
+    ports:
+      - "8443:8443"
+    networks:
+      - test
+
   build_member:
     image: replica_member/local
     build:

--- a/pbm-functional/pytest/example_oidc_setup.py
+++ b/pbm-functional/pytest/example_oidc_setup.py
@@ -1,0 +1,58 @@
+import signal
+import requests
+import testinfra
+from cluster import Cluster
+
+"""
+example setup for pbm using OIDC with ENVIRONMENT:k8s
+creates directory /var/run/secrets/kubernetes.io/serviceaccount
+queries keycloack for access_token and put it into
+/var/run/secrets/kubernetes.io/serviceaccount/token
+to simulate k8s environment
+important: file without newline in the end
+to start:
+docker compose run -ti --rm test python3 -i example_oidc_setup.py
+"""
+
+config = { "_id": "rs1", "members": [{"host": "rs101"}]}
+pbm_mongodb_uri = 'mongodb://127.0.0.1:27017/?authSource=%24external&authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s'
+mongod_extra_args = ('--setParameter authenticationMechanisms=SCRAM-SHA-1,MONGODB-OIDC --setParameter \'' +
+                    'oidcIdentityProviders=[ { ' +
+                    '"issuer": "https://keycloak:8443/realms/test", ' +
+                    '"clientId": "pbmclient", ' +
+                    '"audience": "account", ' +
+                    '"authNamePrefix": "keycloak", ' +
+                    '"useAuthorizationClaim": false, ' +
+                    '"supportsHumanFlows": false, ' +
+                    '"principalName": "client_id" ' +
+                    '} ]\'')
+cluster = Cluster(config,pbm_mongodb_uri=pbm_mongodb_uri,mongod_extra_args=mongod_extra_args)
+
+def handler(signum,frame):
+    cluster.destroy()
+    exit(0)
+
+cluster.destroy()
+cluster.create()
+response=requests.post(
+    'https://keycloak:8443/realms/test/protocol/openid-connect/token',
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": "pbmclient",
+        "client_secret": "pbm-secret"
+    },
+    verify=False
+)
+token = response.json()["access_token"]
+print(token)
+token_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+token_path="/var/run/secrets/kubernetes.io/serviceaccount/token"
+host = testinfra.get_host("docker://rs101")
+host.check_output(f"mkdir -p {token_dir}")
+host.check_output(f"printf %s {token} > {token_path}")
+cluster.setup_pbm()
+cluster.check_pbm_status()
+signal.signal(signal.SIGINT,handler)
+print("\nCluster is prepared and ready to use")
+print("\nPress CTRL-C to destroy and exit")
+

--- a/pbm-functional/pytest/test_oidc.py
+++ b/pbm-functional/pytest/test_oidc.py
@@ -1,0 +1,77 @@
+import pytest
+import pymongo
+import docker
+import requests
+import testinfra
+
+from cluster import Cluster
+
+@pytest.fixture(scope="package")
+def docker_client():
+    return docker.from_env()
+
+@pytest.fixture(scope="package")
+def config():
+    return { "_id": "rs1", "members": [{"host": "rs101"}]}
+
+@pytest.fixture(scope="package")
+def pbm_mongodb_uri():
+    return 'mongodb://127.0.0.1:27017/?authSource=%24external&authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s'
+
+@pytest.fixture(scope="package")
+def mongod_extra_args():
+    args = ('--setParameter authenticationMechanisms=SCRAM-SHA-1,MONGODB-OIDC --setParameter \'' +
+                    'oidcIdentityProviders=[ { ' +
+                    '"issuer": "https://keycloak:8443/realms/test", ' +
+                    '"clientId": "pbmclient", ' +
+                    '"audience": "account", ' +
+                    '"authNamePrefix": "keycloak", ' +
+                    '"useAuthorizationClaim": false, ' +
+                    '"supportsHumanFlows": false, ' +
+                    '"principalName": "client_id" ' +
+                    '} ]\'')
+    return args
+
+@pytest.fixture(scope="package")
+def cluster(config,pbm_mongodb_uri,mongod_extra_args):
+    return Cluster(config, pbm_mongodb_uri=pbm_mongodb_uri, mongod_extra_args=mongod_extra_args)
+
+@pytest.fixture(scope="function")
+def start_cluster(cluster,request):
+    try:
+        cluster.destroy()
+        cluster.create()
+        response=requests.post(
+            'https://keycloak:8443/realms/test/protocol/openid-connect/token',
+            data = {
+                "grant_type": "client_credentials",
+                "client_id": "pbmclient",
+                "client_secret": "pbm-secret"
+            },
+            verify=False
+        )
+        token = response.json()["access_token"]
+        print(token)
+        token_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+        token_path="/var/run/secrets/kubernetes.io/serviceaccount/token"
+        host = testinfra.get_host("docker://rs101")
+        host.check_output(f"mkdir -p {token_dir}")
+        host.check_output(f"printf %s {token} > {token_path}")
+        cluster.setup_pbm()
+        yield True
+    finally:
+        if request.config.getoption("--verbose"):
+            cluster.get_logs()
+        cluster.destroy(cleanup_backups=True)
+
+@pytest.mark.timeout(300,func_only=True)
+def test_logical_PBM_T335(start_cluster,cluster):
+    cluster.check_pbm_status()
+    pymongo.MongoClient(cluster.connection)["test"]["test"].insert_one({})
+    backup=cluster.make_backup("logical")
+    result=pymongo.MongoClient(cluster.connection)["test"]["test"].delete_many({})
+    assert int(result.deleted_count) == 1
+    cluster.make_restore(backup,check_pbm_status=True)
+    assert pymongo.MongoClient(cluster.connection)["test"]["test"].count_documents({}) == 1
+    Cluster.log("Finished successfully")
+


### PR DESCRIPTION
This pull request adds support for OIDC authentication using Keycloak in the PBM functional test environment. It introduces new Docker images and configuration for Keycloak, updates the test cluster setup to enable OIDC, and provides example and automated tests for OIDC integration. The changes make it possible to simulate a Kubernetes environment with OIDC tokens and test PBM with OIDC-enabled MongoDB clusters.

Keycloak OIDC integration:

* Added a new `Dockerfile-keycloak` to build a Keycloak container with a custom realm, clients, users, and SSL certificates for OIDC authentication. The realm is pre-configured for PBM testing scenarios.
* Updated `docker-compose.yaml` to include the new Keycloak service, exposing it on port 8443 for OIDC flows.
* Enhanced `Dockerfile-easyrsa` to generate and install server certificates for the Keycloak container.

Test cluster and OIDC user setup:

* Modified `cluster.py` to create an OIDC user (`keycloak/pbmclient`) in MongoDB when OIDC authentication is enabled, ensuring proper roles for PBM operations. [[1]](diffhunk://#diff-dedbfca7cfbd4f8e10136d58e8813a417764860486af292a893203d745c77620R748-R753) [[2]](diffhunk://#diff-dedbfca7cfbd4f8e10136d58e8813a417764860486af292a893203d745c77620R771-R774)
* Updated the main Dockerfile to trust the test CA for OIDC flows by installing the CA certificate system-wide.

OIDC testing and documentation:

* Added `example_oidc_setup.py`, a script demonstrating how to set up PBM with OIDC in a simulated Kubernetes environment, including token retrieval from Keycloak.
* Introduced `test_oidc.py`, a pytest-based integration test that provisions a cluster with OIDC enabled, retrieves tokens from Keycloak, and verifies backup and restore operations.