### PR TITLE
PCSM. Add cross version test

### DIFF
--- a/.github/workflows/PCSM-FULL.yml
+++ b/.github/workflows/PCSM-FULL.yml
@@ -30,20 +30,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        psmdb: ["6.0", "7.0", "8.0"]
+        psmdb_pair: ["6.0-6.0", "6.0-8.0", "7.0-7.0", "8.0-8.0"]
         shard: [0, 1, 2, 3, 4]
     env:
       PCSM_BRANCH: ${{ github.event.inputs.pcsm_branch || 'main' }}
       GO_VER: ${{ github.event.inputs.go_ver || 'bullseye' }}
     steps:
     - uses: actions/checkout@v4
-    - name: Setup environment with PSMDB ${{ matrix.psmdb }} and PCSM branch ${{ env.PCSM_BRANCH }}
+    - name: Setup environment with PSMDB ${{ matrix.psmdb_pair }} and PCSM branch ${{ env.PCSM_BRANCH }}
       run: |
-        MONGODB_IMAGE=perconalab/percona-server-mongodb:${{ matrix.psmdb }} docker compose build easyrsa
-        MONGODB_IMAGE=perconalab/percona-server-mongodb:${{ matrix.psmdb }} docker compose build
+        SRC_PSMDB="${{ matrix.psmdb_pair }}"; SRC_PSMDB="${SRC_PSMDB%-*}"
+        TGT_PSMDB="${{ matrix.psmdb_pair }}"; TGT_PSMDB="${TGT_PSMDB#*-}"
+        export MONGODB_SRC_IMAGE="perconalab/percona-server-mongodb:${SRC_PSMDB}"
+        export MONGODB_DST_IMAGE="perconalab/percona-server-mongodb:${TGT_PSMDB}"
+        echo "SRC=${MONGODB_SRC_IMAGE}  DST=${MONGODB_DST_IMAGE}"
+        docker compose build easyrsa
+        docker compose build
         docker compose up -d
       working-directory: ./pcsm-pytest
-    - name: Run pytest shard ${{ matrix.shard }} on PSMDB ${{ matrix.psmdb }} and PCSM branch ${{ env.PCSM_BRANCH }}
+    - name: Run pytest shard ${{ matrix.shard }} on PSMDB ${{ matrix.psmdb_pair }} and PCSM branch ${{ env.PCSM_BRANCH }}
       run: |
         docker compose run --rm test pytest -s -v --junitxml=junit.xml --shard-id=${{ matrix.shard }} --num-shards=5 -m 'not jenkins'
       working-directory: ./pcsm-pytest

--- a/pcsm-pytest/conftest.py
+++ b/pcsm-pytest/conftest.py
@@ -138,7 +138,7 @@ def src_cluster(cluster_configs, request):
     if "mongos" in config:
         mongod_extra_args = f"--setParameter periodicNoopIntervalSecs=1 {mongod_extra_args}".strip()
     Cluster.log(f"src_cluster mongod_extra_args: '{mongod_extra_args}'")
-    return Cluster(config, mongod_extra_args=mongod_extra_args)
+    return Cluster(config, mongod_extra_args=mongod_extra_args, mongo_image="mongodb-src/local")
 
 @pytest.fixture(scope="function")
 def dst_cluster(cluster_configs, request):
@@ -149,7 +149,7 @@ def dst_cluster(cluster_configs, request):
     else:
         mongod_extra_args = ""
     Cluster.log(f"dst_cluster mongod_extra_args: '{mongod_extra_args}'")
-    return Cluster(config, mongod_extra_args=mongod_extra_args)
+    return Cluster(config, mongod_extra_args=mongod_extra_args, mongo_image="mongodb-dst/local")
 
 @pytest.fixture(scope="function")
 def csync(src_cluster, dst_cluster):

--- a/pcsm-pytest/data_integrity_check.py
+++ b/pcsm-pytest/data_integrity_check.py
@@ -1,10 +1,17 @@
 import json
 import time
 from contextlib import contextmanager
+import bson
 from pymongo import MongoClient
 from pymongo.errors import PyMongoError, ServerSelectionTimeoutError, NetworkTimeout, AutoReconnect, ExecutionTimeout
 
 from cluster import Cluster
+
+# Fixed codec so doc equality compares raw BSON bytes (Python NaN != NaN)
+_BSON_COMPARE_CODEC = bson.CodecOptions(document_class=dict)
+def _bson_doc_eq(d1, d2):
+    return bson.encode(d1, codec_options=_BSON_COMPARE_CODEC) == \
+           bson.encode(d2, codec_options=_BSON_COMPARE_CODEC)
 
 # Connection error types that should trigger retry
 _CONNECTION_ERRORS = (ServerSelectionTimeoutError, NetworkTimeout, AutoReconnect, ConnectionError)
@@ -85,13 +92,19 @@ def compare_data(db1, db2):
         is_sharded = True
 
     mismatch_summary = []
-    # Hash mismatch is only checked for replica sets, not sharded clusters
+    # Hash mismatch is only checked for replica sets, not sharded clusters.
+    # dbHash on capped collections is skipped; they are validated separately
+    # via record-by-record comparison below
     if not is_sharded:
         all_coll_hash, mismatch_dbs_hash, mismatch_coll_hash = compare_database_hashes(db1_container, db2_container)
         if mismatch_dbs_hash:
             mismatch_summary.extend(mismatch_dbs_hash)
         if mismatch_coll_hash:
             mismatch_summary.extend(mismatch_coll_hash)
+
+    _, capped_mismatches = compare_capped_collections(db1_container, db2_container)
+    if capped_mismatches:
+        mismatch_summary.extend(capped_mismatches)
 
     all_collections, mismatch_dbs_count, mismatch_coll_count = compare_entries_number(db1_container, db2_container)
     mismatch_metadata = compare_collection_metadata(db1_container, db2_container)
@@ -118,6 +131,130 @@ def compare_data(db1, db2):
     Cluster.log(f"Mismatched databases, collections, or indexes found: {mismatch_summary}")
     return False, mismatch_summary
 
+def compare_capped_collections(db1, db2, databases=None):
+    """
+    Record-by-record comparison of capped collections, sorted by _id.
+    Why this exists: dbHash hashes capped collections in natural (insertion) order
+    rather than by _id, which is not portable across independent MongoDB instances
+    (PCSM source vs target) and changed behavior between 6.0 and 7.0.26+
+    (SERVER-82180 / SERVER-86692). So for capped collections we validate
+    correctness via count + per-document equality instead of dbHash.
+    """
+    def resolve_uri(db):
+        if hasattr(db, "connection"):
+            return db.connection
+        if isinstance(db, str) and (db.startswith("mongodb://") or db.startswith("mongodb+srv://")):
+            return db
+        raise ValueError("Invalid database argument: must be cluster object or connection string")
+
+    src_uri = resolve_uri(db1)
+    dst_uri = resolve_uri(db2)
+
+    def list_capped(uri):
+        result = {}
+        with _mongo_client_with_retry(uri) as client:
+            for db_name in client.list_database_names():
+                if db_name in ["admin", "local", "config", "percona_clustersync_mongodb"]:
+                    continue
+                if databases is not None and db_name not in databases:
+                    continue
+                db = client[db_name]
+                try:
+                    capped = [coll["name"] for coll in db.list_collections(filter={"options.capped": True})]
+                except PyMongoError as e:
+                    Cluster.log(f"Warning: could not list capped collections in '{db_name}': {e}")
+                    continue
+                if capped:
+                    result[db_name] = capped
+        return result
+
+    Cluster.log("Comparing capped collections record-by-record (sorted by _id)...")
+    src_capped = list_capped(src_uri)
+    dst_capped = list_capped(dst_uri)
+
+    all_capped = set()
+    for db_name, colls in src_capped.items():
+        for c in colls:
+            all_capped.add(f"{db_name}.{c}")
+    for db_name, colls in dst_capped.items():
+        for c in colls:
+            all_capped.add(f"{db_name}.{c}")
+
+    if not all_capped:
+        Cluster.log("No capped collections found to compare")
+        return True, []
+
+    mismatches = []
+    with _mongo_client_with_retry(src_uri) as src_client, \
+         _mongo_client_with_retry(dst_uri) as dst_client:
+        for full_name in sorted(all_capped):
+            db_name, coll_name = full_name.split(".", 1)
+            src_present = coll_name in src_capped.get(db_name, [])
+            dst_present = coll_name in dst_capped.get(db_name, [])
+            if not src_present:
+                mismatches.append((full_name, "missing in src DB"))
+                Cluster.log(f"Capped '{full_name}' exists in destination_DB but not in source_DB")
+                continue
+            if not dst_present:
+                mismatches.append((full_name, "missing in dst DB"))
+                Cluster.log(f"Capped '{full_name}' exists in source_DB but not in destination_DB")
+                continue
+
+            src_coll = src_client[db_name][coll_name]
+            dst_coll = dst_client[db_name][coll_name]
+            try:
+                src_count = src_coll.count_documents({})
+                dst_count = dst_coll.count_documents({})
+            except PyMongoError as e:
+                Cluster.log(f"Capped '{full_name}': count failed: {e}")
+                mismatches.append((full_name, f"count error: {e}"))
+                continue
+
+            if src_count != dst_count:
+                mismatches.append((full_name, f"record count mismatch: src={src_count}, dst={dst_count}"))
+                Cluster.log(f"Capped '{full_name}': record count mismatch {src_count} != {dst_count}")
+                continue
+
+            # Stream both cursors in lockstep instead of materializing them
+            src_cursor = src_coll.find({}, sort=[("_id", 1)])
+            dst_cursor = dst_coll.find({}, sort=[("_id", 1)])
+            differing = 0
+            try:
+                for i, (s_doc, d_doc) in enumerate(zip(src_cursor, dst_cursor)):
+                    # Byte-level BSON compare so NaN, Decimal128(NaN), binary
+                    # subtypes etc. are not flagged as different just because
+                    # Python's value-level equality says so (NaN != NaN)
+                    if _bson_doc_eq(s_doc, d_doc):
+                        continue
+                    differing += 1
+                    if differing <= 3:
+                        try:
+                            s_hex = bson.encode(s_doc, codec_options=_BSON_COMPARE_CODEC).hex()
+                            d_hex = bson.encode(d_doc, codec_options=_BSON_COMPARE_CODEC).hex()
+                        except Exception:
+                            s_hex = d_hex = "<unencodable>"
+                        Cluster.log(
+                            f"Capped '{full_name}' doc[{i}] mismatch:\n"
+                            f"  src: {s_doc}\n"
+                            f"  dst: {d_doc}\n"
+                            f"  src bson: {s_hex}\n"
+                            f"  dst bson: {d_hex}")
+            except PyMongoError as e:
+                Cluster.log(f"Capped '{full_name}': find failed: {e}")
+                mismatches.append((full_name, f"find error: {e}"))
+                continue
+            finally:
+                src_cursor.close()
+                dst_cursor.close()
+
+            if differing:
+                mismatches.append((full_name, f"{differing} document(s) differ"))
+                Cluster.log(f"Capped '{full_name}': {differing} of {src_count} docs differ")
+            else:
+                Cluster.log(f"Capped '{full_name}': {src_count} docs match")
+
+    return len(mismatches) == 0, mismatches
+
 def compare_database_hashes(db1_container, db2_container):
     def get_db_hashes_and_collections(uri):
         with _mongo_client_with_retry(uri) as client:
@@ -128,12 +265,23 @@ def compare_database_hashes(db1_container, db2_container):
                 if db_name in ["admin", "local", "config", "percona_clustersync_mongodb"]:
                     continue
                 db = client[db_name]
-                collections = [name for name in db.list_collection_names()]
+                # Exclude capped collections - dbHash hashes them in natural
+                # (insertion) order which is not portable across independent
+                # clusters or MongoDB versions (SERVER-82180 / SERVER-86692).
+                # Capped collections are validated via record-by-record
+                # comparison in compare_capped_collections()
                 try:
-                    if collections:
-                        result = db.command("dbHash", collections=collections)
-                    else:
-                        result = db.command("dbHash")
+                    non_capped = [
+                        coll["name"] for coll in db.list_collections()
+                        if not coll.get("options", {}).get("capped")
+                    ]
+                except PyMongoError as e:
+                    Cluster.log(f"Warning: could not list collections in {db_name}: {e}")
+                    continue
+                if not non_capped:
+                    continue
+                try:
+                    result = db.command("dbHash", collections=non_capped)
                     db_hashes[db_name] = result.get("md5")
                     for coll, coll_hash in result.get("collections", {}).items():
                         collection_hashes[f"{db_name}.{coll}"] = coll_hash

--- a/pcsm-pytest/docker-compose.yaml
+++ b/pcsm-pytest/docker-compose.yaml
@@ -24,6 +24,28 @@ services:
     depends_on:
       - easyrsa
 
+  mongodb-src:
+    image: mongodb-src/local
+    build:
+      dockerfile: ./Dockerfile-mongodb
+      context: .
+      args:
+        - MONGODB_IMAGE=${MONGODB_SRC_IMAGE:-${MONGODB_IMAGE:-percona/percona-server-mongodb}}
+    command: /bin/bash
+    depends_on:
+      - easyrsa
+
+  mongodb-dst:
+    image: mongodb-dst/local
+    build:
+      dockerfile: ./Dockerfile-mongodb
+      context: .
+      args:
+        - MONGODB_IMAGE=${MONGODB_DST_IMAGE:-${MONGODB_IMAGE:-percona/percona-server-mongodb}}
+    command: /bin/bash
+    depends_on:
+      - easyrsa
+
   csync:
     image: csync/local
     build:

--- a/pcsm-pytest/example_cluster.py
+++ b/pcsm-pytest/example_cluster.py
@@ -14,8 +14,8 @@ There is the way not to close the connection but return known or unknown error t
 See the examples in jstests/core/failcommand_failpoint.js
 """
 
-dstRS = Cluster({ "_id": "rs2", "members": [{"host":"rs201"}]},mongod_extra_args='--setParameter enableTestCommands=1')
-srcRS = Cluster({ "_id": "rs1", "members": [{"host":"rs101"}]},mongod_extra_args='--setParameter enableTestCommands=1')
+dstRS = Cluster({ "_id": "rs2", "members": [{"host":"rs201"}]},mongod_extra_args='--setParameter enableTestCommands=1', mongo_image="mongodb-dst/local")
+srcRS = Cluster({ "_id": "rs1", "members": [{"host":"rs101"}]},mongod_extra_args='--setParameter enableTestCommands=1', mongo_image="mongodb-src/local")
 csync = Clustersync('csync',srcRS.csync_connection + '&appName=pcsm', dstRS.csync_connection + '&appName=pcsm')
 
 def configure_failpoint_failcommand(connection,commands,mode):

--- a/pcsm-pytest/example_rs.py
+++ b/pcsm-pytest/example_rs.py
@@ -8,8 +8,8 @@ from data_generator import generate_dummy_data
 # To destroy setup:
 # docker-compose run --env CLEANUP=true test python example_rs.py
 
-srcRS = Cluster({"_id": "rs1", "members": [{"host": "rs101"}]})
-dstRS = Cluster({"_id": "rs2", "members": [{"host": "rs201"}]})
+srcRS = Cluster({"_id": "rs1", "members": [{"host": "rs101"}]}, mongo_image="mongodb-src/local")
+dstRS = Cluster({"_id": "rs2", "members": [{"host": "rs201"}]}, mongo_image="mongodb-dst/local")
 csync = Clustersync("csync", srcRS.csync_connection, dstRS.csync_connection)
 setup = os.environ.get("SETUP", "").lower() == "true"
 cleanup = os.environ.get("CLEANUP", "").lower() == "true"

--- a/pcsm-pytest/example_shard.py
+++ b/pcsm-pytest/example_shard.py
@@ -15,7 +15,7 @@ srcShard = Cluster({
         {"_id": "rs1", "members": [{"host": "rs101"}]},
         {"_id": "rs2", "members": [{"host": "rs201"}]}
     ]
-})
+}, mongo_image="mongodb-src/local")
 dstShard = Cluster({
     "mongos": "mongos2",
     "configserver": {"_id": "rscfg2", "members": [{"host": "rscfg201"}]},
@@ -23,7 +23,7 @@ dstShard = Cluster({
         {"_id": "rs3", "members": [{"host": "rs301"}]},
         {"_id": "rs4", "members": [{"host": "rs401"}]}
     ]
-})
+}, mongo_image="mongodb-dst/local")
 csync = Clustersync("csync", srcShard.csync_connection, dstShard.csync_connection)
 setup = os.environ.get("SETUP", "").lower() == "true"
 cleanup = os.environ.get("CLEANUP", "").lower() == "true"

--- a/pcsm-pytest/readme.md
+++ b/pcsm-pytest/readme.md
@@ -1,9 +1,28 @@
 ## Setup ##
 
+`docker-compose build` produces three MongoDB images so single-version and cross-version layouts can coexist:
+
+| Image               | When it is used                                       | Base image (build arg)                             |
+| ------------------- | ----------------------------------------------------- | -------------------------------------------------- |
+| `mongodb/local`     | Same MongoDB version on source and target             | `MONGODB_IMAGE`                                    |
+| `mongodb-src/local` | Source cluster when source and target versions differ | `MONGODB_SRC_IMAGE`, falls back to `MONGODB_IMAGE` |
+| `mongodb-dst/local` | Target cluster when source and target versions differ | `MONGODB_DST_IMAGE`, falls back to `MONGODB_IMAGE` |
+
 Environment variables for the setup:
-1) **MONGODB_IMAGE** (default `percona/percona-server-mongodb:latest`) - base image for the tests
-2) **PCSM_BRANCH** (default `main`) - branch, tag, or commit hash to build PCSM from
-3) **GO_VER** (default `latest`) - golang version
+1) **MONGODB_IMAGE** (default `percona/percona-server-mongodb:latest`) - base image used everywhere when no per-side override is set
+2) **MONGODB_SRC_IMAGE** (optional, falls back to `MONGODB_IMAGE`) - base image for the source cluster, used to build the `mongodb-src/local` image
+3) **MONGODB_DST_IMAGE** (optional, falls back to `MONGODB_IMAGE`) - base image for the target cluster, used to build the `mongodb-dst/local` image
+4) **PCSM_BRANCH** (default `main`) - branch, tag, or commit hash to build PCSM from
+5) **GO_VER** (default `latest`) - golang version
+
+To run the suite with different MongoDB versions on source and target (cross-version replication), export both `MONGODB_SRC_IMAGE` and `MONGODB_DST_IMAGE` before building:
+
+```bash
+export MONGODB_SRC_IMAGE=perconalab/percona-server-mongodb:6.0
+export MONGODB_DST_IMAGE=perconalab/percona-server-mongodb:7.0
+docker-compose build
+docker-compose up -d
+```
 
 ```bash
 docker-compose build                          # Build docker images

--- a/pcsm-pytest/test_arguments_and_env_vars.py
+++ b/pcsm-pytest/test_arguments_and_env_vars.py
@@ -13,7 +13,7 @@ from data_generator import create_all_types_db
 def src_cluster():
     """Create src cluster once per module"""
     config = get_cluster_config("replicaset")
-    cluster = Cluster(config['src_config'])
+    cluster = Cluster(config['src_config'], mongo_image="mongodb-src/local")
     cluster.create()
     yield cluster
     cluster.destroy()
@@ -22,7 +22,7 @@ def src_cluster():
 def dst_cluster():
     """Create dst cluster once per module"""
     config = get_cluster_config("replicaset")
-    cluster = Cluster(config['dst_config'])
+    cluster = Cluster(config['dst_config'], mongo_image="mongodb-dst/local")
     cluster.create()
     yield cluster
     cluster.destroy()

--- a/pcsm-pytest/test_connection_rs.py
+++ b/pcsm-pytest/test_connection_rs.py
@@ -23,12 +23,12 @@ def _make_config(rs_name, host):
 @pytest.fixture(scope="module")
 def srcRS(mongod_extra_args):
     config = _make_config("rs1", "rs101")
-    return Cluster(config, mongod_extra_args=mongod_extra_args)
+    return Cluster(config, mongod_extra_args=mongod_extra_args, mongo_image="mongodb-src/local")
 
 @pytest.fixture(scope="module")
 def dstRS(mongod_extra_args):
     config = _make_config("rs2", "rs201")
-    return Cluster(config, mongod_extra_args=mongod_extra_args)
+    return Cluster(config, mongod_extra_args=mongod_extra_args, mongo_image="mongodb-dst/local")
 
 # Test case 1: check SCRAM authentication with TLS connection and tlsInsecure
 # Test case 2: check SCRAM authentication with TLS connection and tlsCAFile

--- a/pcsm-pytest/test_connection_shard.py
+++ b/pcsm-pytest/test_connection_shard.py
@@ -31,7 +31,7 @@ def srcCluster(mongod_extra_args, mongos_extra_args):
             {"_id": "rs2", "members": [{"host": "rs201"}]}
         ]
     }
-    return Cluster(config, mongod_extra_args=mongod_extra_args, mongos_extra_args=mongos_extra_args)
+    return Cluster(config, mongod_extra_args=mongod_extra_args, mongos_extra_args=mongos_extra_args, mongo_image="mongodb-src/local")
 
 @pytest.fixture(scope="module")
 def dstCluster(mongod_extra_args, mongos_extra_args):
@@ -43,7 +43,7 @@ def dstCluster(mongod_extra_args, mongos_extra_args):
             {"_id": "rs4", "members": [{"host": "rs401"}]}
         ]
     }
-    return Cluster(config, mongod_extra_args=mongod_extra_args, mongos_extra_args=mongos_extra_args)
+    return Cluster(config, mongod_extra_args=mongod_extra_args, mongos_extra_args=mongos_extra_args, mongo_image="mongodb-dst/local")
 
 # Test case 1: check SCRAM authentication with TLS connection and tlsInsecure
 # Test case 2: check SCRAM authentication with TLS connection and tlsCAFile

--- a/pcsm-pytest/test_data_integrity_check.py
+++ b/pcsm-pytest/test_data_integrity_check.py
@@ -34,6 +34,8 @@ def test_data_integrity_check_PML_T1(start_cluster, src_cluster, dst_cluster):
         ("test_db1", "test_coll10"),
         ("test_db1", "test_coll11"),
         ("test_db1", "test_coll12"),
+        ("test_db1", "test_coll13"),
+        ("test_db1", "test_coll14"),
     ]
 
     # Test 1: Capped collection options mismatch
@@ -57,6 +59,23 @@ def test_data_integrity_check_PML_T1(start_cluster, src_cluster, dst_cluster):
     # Test 6: Record count mismatch
     dst["test_db1"]["test_coll7"].delete_one({"key": 9})
 
+    # Test 7: Capped collection with matching options/count but a mutated doc.
+    # Covers the record-by-record BSON compare path that the options-mismatch
+    # case in Test 1 cannot reach.
+    capped_docs = [{"_id": i, "payload": f"value-{i}"} for i in range(20)]
+    src["test_db1"].create_collection("test_coll13", capped=True, size=1024 * 1024, max=100)
+    dst["test_db1"].create_collection("test_coll13", capped=True, size=1024 * 1024, max=100)
+    src["test_db1"]["test_coll13"].insert_many([dict(d) for d in capped_docs])
+    dst["test_db1"]["test_coll13"].insert_many([dict(d) for d in capped_docs])
+    dst["test_db1"]["test_coll13"].update_one({"_id": 7}, {"$set": {"payload": "tampered"}})
+
+    # Test 8: Capped collection with identical content (negative control for
+    # Test 7 - must NOT show up in the mismatch summary).
+    src["test_db1"].create_collection("test_coll14", capped=True, size=1024 * 1024, max=100)
+    dst["test_db1"].create_collection("test_coll14", capped=True, size=1024 * 1024, max=100)
+    src["test_db1"]["test_coll14"].insert_many([dict(d) for d in capped_docs])
+    dst["test_db1"]["test_coll14"].insert_many([dict(d) for d in capped_docs])
+
     expected_mismatches = [
         ("test_db1.test_coll7", "record count mismatch"),
         ("test_db1.test_coll8", "options mismatch"),
@@ -64,6 +83,7 @@ def test_data_integrity_check_PML_T1(start_cluster, src_cluster, dst_cluster):
         ("test_db1.test_coll10", "options mismatch"),
         ("test_db1.test_coll11", "missing in dst DB"),
         ("test_db1.test_coll12", "missing in src DB"),
+        ("test_db1.test_coll13", "1 document(s) differ"),
     ]
 
     # Hash mismatch is only checked for replica sets, not sharded clusters
@@ -77,6 +97,10 @@ def test_data_integrity_check_PML_T1(start_cluster, src_cluster, dst_cluster):
         assert collection in summary, \
             f"Mismatch for collection {collection} isn't detected"
 
+    # Negative control: identical-content capped collection must not be flagged
+    assert not any(name == "test_db1.test_coll14" for name, _ in summary), \
+        f"Untampered capped collection 'test_coll14' wrongly flagged: {summary}"
+
     # Fix mismatches
     for db_name, coll_name in collections_new:
         dst[db_name][coll_name].drop_indexes()
@@ -87,6 +111,8 @@ def test_data_integrity_check_PML_T1(start_cluster, src_cluster, dst_cluster):
     dst["test_db1"].create_collection("test_coll10", changeStreamPreAndPostImages={"enabled": True})
     src["test_db1"]["test_coll7"].delete_one({"key": 9})
     src["test_db1"].drop_collection("test_coll11")
+    src["test_db1"].drop_collection("test_coll13")
+    src["test_db1"].drop_collection("test_coll14")
 
     result, _ = compare_data(src_cluster, dst_cluster)
     assert result is True, "Data should match again after reverting modifications"

--- a/pcsm-pytest/test_failcommands_rs.py
+++ b/pcsm-pytest/test_failcommands_rs.py
@@ -11,11 +11,11 @@ from clustersync import Clustersync
 
 @pytest.fixture(scope="module")
 def dstRS():
-    return Cluster({ "_id": "rs2", "members": [{"host":"rs201"}]},mongod_extra_args='--setParameter enableTestCommands=1')
+    return Cluster({ "_id": "rs2", "members": [{"host":"rs201"}]},mongod_extra_args='--setParameter enableTestCommands=1', mongo_image="mongodb-dst/local")
 
 @pytest.fixture(scope="module")
 def srcRS():
-    return Cluster({ "_id": "rs1", "members": [{"host":"rs101"}]},mongod_extra_args='--setParameter enableTestCommands=1 --oplogSize 20')
+    return Cluster({ "_id": "rs1", "members": [{"host":"rs101"}]},mongod_extra_args='--setParameter enableTestCommands=1 --oplogSize 20', mongo_image="mongodb-src/local")
 
 @pytest.fixture(scope="module")
 def csync(srcRS,dstRS):

--- a/pcsm-pytest/test_load_rs.py
+++ b/pcsm-pytest/test_load_rs.py
@@ -29,8 +29,8 @@ def csync(cluster_manager):
 def cluster_manager():
     setup = os.environ.get("SETUP", "").lower() == "true"
     cleanup = os.environ.get("CLEANUP", "").lower() == "true"
-    srcRS = Cluster({"_id": "rs1", "members": [{"host": "rs101"}]})
-    dstRS = Cluster({"_id": "rs2", "members": [{"host": "rs201"}]})
+    srcRS = Cluster({"_id": "rs1", "members": [{"host": "rs101"}]}, mongo_image="mongodb-src/local")
+    dstRS = Cluster({"_id": "rs2", "members": [{"host": "rs201"}]}, mongo_image="mongodb-dst/local")
     if setup:
         srcRS.create()
         dstRS.create()


### PR DESCRIPTION
This pull request introduces support for running tests with different MongoDB versions for source and target clusters, enabling cross-version replication and data integrity testing. The changes include updates to the Docker Compose setup, test cluster instantiation, and significant improvements to the data integrity check logic, especially for capped collections.

Key changes:

**Cross-version cluster support and Docker Compose updates:**

* Split the single `mongodb` service in `docker-compose.yaml` into `mongodb-src` and `mongodb-dst`, allowing independent builds and images for source and destination clusters. Environment variables `MONGODB_SRC_IMAGE` and `MONGODB_DST_IMAGE` are now supported for per-cluster version selection.
* Updated the documentation in `readme.md` to explain how to configure and run tests with different MongoDB versions for source and target.

**Test and fixture updates for explicit image selection:**
* All test cluster instantiations (`Cluster` objects) in test files and fixtures now explicitly set the `mongo_image` parameter to either `mongodb-src/local` or `mongodb-dst/local`, ensuring correct image usage throughout the test suite. 
**Data integrity check improvements:**
* Added a robust record-by-record comparison for capped collections (`compare_capped_collections`), addressing issues where `dbHash` is not portable across MongoDB versions or clusters due to natural order hashing. This ensures capped collections are validated for correctness regardless of version differences.
* Modified the database hash comparison to exclude capped collections, delegating their validation to the new comparison function, and improved logging and error handling for collection listing and comparison.

These changes collectively enable reliable cross-version testing and more accurate data integrity validation, especially for capped collections, across independently configured MongoDB source and target clusters.