### PR TITLE
PS4M example for local setup

### DIFF
--- a/PS4M-local/README.md
+++ b/PS4M-local/README.md
@@ -1,0 +1,290 @@
+# PS4M-local
+
+Local Docker Compose stack for **Percona Search for MongoDB (PS4M)**: a single-node PSMDB replica set with `mongot` for MongoDB Search.
+
+| Service | Image | Host ports |
+|---------|-------|------------|
+| `mongod` | `perconalab/percona-server-mongodb:8.3.4-1` | `27017` |
+| `mongot` | `perconalab/percona-server-mongodb-mongot:0.51.0-1` | `27028` (gRPC), `8080` (readiness) |
+
+Replica set name: `rs`. Config lives under `config/` (`mongod.conf`, `mongot.yml`, shared `keyfile`).
+
+On first start, mongod creates an admin user for client access:
+
+| User | Password | Role |
+|------|----------|------|
+| `root` | `root` | `root` on `admin` |
+
+## Prerequisites
+
+- Docker Engine with Compose v2
+- `mongosh` installed on the host
+
+## Quick start
+
+```bash
+cd PS4M-local
+docker compose up -d
+docker compose ps
+```
+
+Wait until both services are healthy:
+
+```bash
+mongosh "mongodb://root:root@127.0.0.1:27017/?authSource=admin&directConnection=true" \
+  --quiet --eval 'db.hello().isWritablePrimary'
+
+curl -fsS http://127.0.0.1:8080/ready
+```
+
+Stop (keep data volumes) or remove volumes too:
+
+```bash
+docker compose down
+docker compose down -v
+```
+
+If volumes already exist from an older run without the `root` user, recreate them with `docker compose down -v`.
+
+## Connect
+
+Open an interactive shell with local `mongosh`:
+
+```bash
+mongosh "mongodb://root:root@127.0.0.1:27017/?authSource=admin&directConnection=true"
+```
+
+All examples below are run inside that session. Snippets use `db.getSiblingDB(...)` instead of `use`, so each block can be pasted and run as a whole.
+
+---
+
+## Example: full-text search (`$search`)
+
+Full-text search indexes document fields with Lucene. `mongot` builds the index and serves `$search` queries.
+
+### 1. Create the search index
+
+The collection must exist before you create a search index. Dynamic mappings index all supported field types automatically.
+
+```javascript
+db = db.getSiblingDB("search_demo")
+db.movies.drop()
+db.createCollection("movies")
+
+db.movies.createSearchIndex(
+  "default",
+  { mappings: { dynamic: true } }
+)
+
+while (true) {
+  const idxs = db.movies.getSearchIndexes()
+  if (idxs.length && idxs.every(i => i.status === "READY")) break
+  print("index status:", JSON.stringify(idxs))
+  sleep(2000)
+}
+```
+
+### 2. Upload data
+
+```javascript
+db = db.getSiblingDB("search_demo")
+
+db.movies.insertMany([
+  { title: "The Matrix", plot: "A computer hacker learns about reality" },
+  { title: "Inception", plot: "Dreams within dreams" },
+  { title: "The Martian", plot: "An astronaut is stranded on Mars" }
+])
+```
+
+Give mongot a moment to sync new documents, then confirm:
+
+```javascript
+db = db.getSiblingDB("search_demo")
+db.movies.getSearchIndexes()
+```
+
+### 3. Aggregate with `$search`
+
+```javascript
+db = db.getSiblingDB("search_demo")
+
+db.movies.aggregate([
+  {
+    $search: {
+      text: { query: "hacker", path: "plot" }
+    }
+  },
+  {
+    $project: {
+      _id: 0,
+      title: 1,
+      plot: 1,
+      score: { $meta: "searchScore" }
+    }
+  }
+])
+```
+
+Expected result includes *The Matrix*.
+
+### Optional: compound query
+
+Combine must / mustNot clauses:
+
+```javascript
+db = db.getSiblingDB("search_demo")
+
+db.movies.aggregate([
+  {
+    $search: {
+      compound: {
+        must: [{ text: { query: "mars", path: "plot" } }],
+        mustNot: [{ text: { query: "dream", path: "plot" } }]
+      }
+    }
+  },
+  { $project: { _id: 0, title: 1, plot: 1 } }
+])
+```
+
+### Drop the index
+
+```javascript
+db = db.getSiblingDB("search_demo")
+db.movies.dropSearchIndex("default")
+```
+
+---
+
+## Example: vector search (`$vectorSearch`) with manual embeddings
+
+### What are vectors?
+
+A **vector** (embedding) is a fixed-length list of floating-point numbers that represents the meaning of text, an image, or other data in a numeric space. Similar items land close together; unrelated items land far apart.
+
+In production, you usually generate embeddings with a model (for example OpenAI, Hugging Face, or Voyage). Here we use **manual embeddings**: short arrays you write by hand so the flow is easy to follow. Real models typically produce 384–1536 dimensions; this demo uses 4.
+
+`$vectorSearch` finds documents whose stored vectors are closest to a **query vector**, using a similarity metric such as `cosine`, `euclidean`, or `dotProduct`. The index `numDimensions` must match the length of every stored vector and the query vector.
+
+### 1. Create the vector search index
+
+The collection must exist before you create a search index.
+
+```javascript
+db = db.getSiblingDB("vector_demo")
+db.items.drop()
+db.createCollection("items")
+
+db.items.createSearchIndex(
+  "vector_index",
+  "vectorSearch",
+  {
+    fields: [
+      {
+        type: "vector",
+        path: "embedding",
+        numDimensions: 4,
+        similarity: "cosine"
+      }
+    ]
+  }
+)
+
+while (true) {
+  const idxs = db.items.getSearchIndexes("vector_index")
+  if (idxs.length && idxs.every(i => i.status === "READY")) break
+  print("index status:", JSON.stringify(idxs))
+  sleep(2000)
+}
+```
+
+### 2. Upload data
+
+Each document stores its embedding under `embedding`. The first two items are “fruit-like” (high first component); the third is different.
+
+```javascript
+db = db.getSiblingDB("vector_demo")
+
+db.items.insertMany([
+  {
+    name: "red apple",
+    embedding: [0.95, 0.02, 0.01, 0.10]
+  },
+  {
+    name: "green pear",
+    embedding: [0.80, 0.15, 0.05, 0.12]
+  },
+  {
+    name: "blue car",
+    embedding: [0.05, 0.90, 0.20, 0.05]
+  }
+])
+```
+
+### 3. Aggregate with `$vectorSearch`
+
+Pass a query vector close to “red apple”. `numCandidates` controls how many approx. neighbors to score; `limit` is how many to return.
+
+```javascript
+db = db.getSiblingDB("vector_demo")
+
+db.items.aggregate([
+  {
+    $vectorSearch: {
+      index: "vector_index",
+      path: "embedding",
+      queryVector: [0.92, 0.03, 0.02, 0.11],
+      numCandidates: 10,
+      limit: 3
+    }
+  },
+  {
+    $project: {
+      _id: 0,
+      name: 1,
+      score: { $meta: "vectorSearchScore" }
+    }
+  }
+])
+```
+
+Expected top hit is *red apple*, then *green pear*, then *blue car*.
+
+For real workloads, replace these 4-d arrays with model output and set `numDimensions` to that model’s size (for example `768` or `1536`).
+
+### Drop the index
+
+```javascript
+db = db.getSiblingDB("vector_demo")
+db.items.dropSearchIndex("vector_index")
+```
+
+---
+
+## Logs and troubleshooting
+
+```bash
+docker compose logs -f mongod
+docker compose logs -f mongot
+```
+
+| Check | Command |
+|-------|---------|
+| Replica set | `mongosh "mongodb://root:root@127.0.0.1:27017/?authSource=admin&directConnection=true" --quiet --eval 'rs.status().ok'` |
+| mongod → mongot | Confirm `mongotHost` / `searchIndexManagementHostAndPort` in `config/mongod.conf` |
+| Keyfile perms | Host file `config/keyfile` should be mode `400`; compose copies it into each container |
+| Reset stack | `docker compose down -v && docker compose up -d` |
+
+`mongot` starts only after `mongod` reports healthy (writable primary). First startup initializes the replica set, creates the `root` user, and may take ~30s.
+
+## Layout
+
+```
+PS4M-local/
+├── docker-compose.yml
+├── README.md
+└── config/
+    ├── keyfile
+    ├── mongod.conf
+    └── mongot.yml
+```

--- a/PS4M-local/config/keyfile
+++ b/PS4M-local/config/keyfile
@@ -1,0 +1,1 @@
+Thiskeyisonlyforrunningthesuitewithauthenticationdontuseitinanytestsdirectly

--- a/PS4M-local/config/mongod.conf
+++ b/PS4M-local/config/mongod.conf
@@ -1,0 +1,30 @@
+# Matches mongot_community_fixture_e2e_single_node.yml + ReplicaSetFixture defaults.
+
+net:
+  port: 27017
+  bindIpAll: true
+
+replication:
+  replSetName: rs
+
+security:
+  keyFile: /etc/mongodb/keyfile
+
+setParameter:
+  enableTestCommands: 1
+  featureFlagEgressGrpcForSearch: true
+  useGrpcForSearch: 1
+  skipAuthenticationToMongot: true
+  mongotHost: mongot:27028
+  searchIndexManagementHostAndPort: mongot:27028
+
+storage:
+  dbPath: /var/lib/mongo
+
+systemLog:
+  destination: file
+  path: /var/lib/mongo/mongod.log
+  logAppend: true
+
+processManagement:
+  fork: false

--- a/PS4M-local/config/mongot.yml
+++ b/PS4M-local/config/mongot.yml
@@ -1,0 +1,27 @@
+# Matches MongoTCommunityFixture._generate_mongot_community_config().
+
+syncSource:
+  replicaSet:
+    hostAndPort: mongod:27017
+    scramAuth:
+      username: __system
+      passwordFile: /etc/mongot/secrets/passwordFile
+      authSource: local
+
+storage:
+  dataPath: /var/lib/mongot
+
+server:
+  grpc:
+    address: 0.0.0.0:27028
+    tls:
+      mode: disabled
+
+metrics:
+  enabled: false
+
+healthCheck:
+  address: 0.0.0.0:8080
+
+logging:
+  verbosity: INFO

--- a/PS4M-local/docker-compose.yml
+++ b/PS4M-local/docker-compose.yml
@@ -1,0 +1,102 @@
+name: PS4M-local
+
+services:
+  mongod:
+    image: perconalab/percona-server-mongodb:8.3.4-1
+    user: "0"
+    hostname: mongod
+    command:
+      - bash
+      - -ec
+      - |
+        install -d -m 0750 -o mongodb -g root /etc/mongodb
+        install -m 0400 -o mongodb -g root /mnt/keyfile /etc/mongodb/keyfile
+        chown -R mongodb:0 /var/lib/mongo
+        if [ ! -f /var/lib/mongo/.replset-init ]; then
+          gosu mongodb:1001 /entrypoint.sh mongod --config /etc/mongod.conf &
+          pid=$$!
+          until mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; do sleep 1; done
+          mongosh --quiet --eval 'rs.initiate({_id:"rs", members:[{_id:0, host:"mongod:27017"}]})'
+          until mongosh --quiet --eval 'db.hello().isWritablePrimary' >/dev/null 2>&1; do sleep 1; done
+          mongosh --quiet --eval '
+            db.getSiblingDB("admin").createUser({
+              user: "root",
+              pwd: "root",
+              roles: [{ role: "root", db: "admin" }]
+            })
+          '
+          kill -TERM "$$pid"
+          wait "$$pid"
+          touch /var/lib/mongo/.replset-init
+        fi
+        exec gosu mongodb:1001 /entrypoint.sh mongod --config /etc/mongod.conf
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./config/mongod.conf:/etc/mongod.conf:ro
+      - ./config/keyfile:/mnt/keyfile:ro
+      - mongod_data:/var/lib/mongo
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "mongosh",
+          "-u",
+          "root",
+          "-p",
+          "root",
+          "--authenticationDatabase",
+          "admin",
+          "--quiet",
+          "--eval",
+          "db.hello().isWritablePrimary",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - ps4m-local
+
+  mongot:
+    image: perconalab/percona-server-mongodb-mongot:0.51.0-1
+    user: "0"
+    hostname: mongot
+    entrypoint:
+      - bash
+      - -ec
+      - |
+        install -d -m 0750 -o mongodb -g root /etc/mongot/secrets
+        install -m 0400 -o mongodb -g root /mnt/keyfile /etc/mongot/secrets/passwordFile
+        chown -R mongodb:0 /var/lib/mongot
+        exec setpriv --reuid=1001 --regid=0 --init-groups /entrypoint.sh mongot --config /etc/mongot/mongot.yml
+    ports:
+      - "27028:27028"
+      - "8080:8080"
+    volumes:
+      - ./config/mongot.yml:/etc/mongot/mongot.yml:ro
+      - ./config/keyfile:/mnt/keyfile:ro
+      - mongot_data:/var/lib/mongot
+    depends_on:
+      mongod:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS http://127.0.0.1:8080/ready >/dev/null || exit 1",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - ps4m-local
+
+volumes:
+  mongod_data:
+  mongot_data:
+
+networks:
+  ps4m-local:
+    driver: bridge


### PR DESCRIPTION
This pull request introduces a complete local development stack for Percona Search for MongoDB (PS4M), using Docker Compose. It provides a single-node replica set of Percona Server for MongoDB (`mongod`) and a `mongot` service for search functionality, along with all necessary configuration, secrets, and a comprehensive README with usage instructions and examples.

The most important changes are:

**Docker Compose Stack and Service Initialization**
- Added `docker-compose.yml` to define `mongod` and `mongot` services, including initialization logic for replica set, user creation, health checks, and service dependencies. Data is persisted in Docker volumes.

**Configuration and Secrets**
- Added `config/mongod.conf` and `config/mongot.yml` for service configuration, enabling authentication, replica set, gRPC search, and proper service wiring. [[1]](diffhunk://#diff-fee405c222e56415d742e078c793f25b6f987106b2366e0aef1de96d17add333R1-R30) [[2]](diffhunk://#diff-f4ed1b35a31f578a03b5e45154fa35234c26e26da10d1c361f0b9b94aef945feR1-R27)
- Added a shared `config/keyfile` for internal authentication between services.

**Documentation and Usage Examples**
- Added a detailed `README.md` explaining prerequisites, setup, connection instructions, and troubleshooting. Includes step-by-step examples for full-text and vector search, with ready-to-run `mongosh` snippets.

These changes together provide a ready-to-use local environment for experimenting with Percona Search for MongoDB, including both text and vector search capabilities.